### PR TITLE
Bash scripts for checking and restarting server

### DIFF
--- a/Automation/start-server.sh
+++ b/Automation/start-server.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd ~/Armchair-Strategist
+source ./env/bin/activate
+gunicorn app:server -b :8000 >/dev/null 2>./Automation/dash.log &
+sleep 3
+pgrep gunicorn && lsof -i :8000
+

--- a/Automation/sync-code.sh
+++ b/Automation/sync-code.sh
@@ -10,6 +10,9 @@ handle_failure() {
     error_line=$BASH_LINENO
     error_command=$BASH_COMMAND
 
+    # relaunch server even if auto-pull fails
+    ./Automation/start_server.sh
+
     aws sns publish --topic-arn arn:aws:sns:us-east-2:637423600104:Armchair-Strategist --message file://./Automation/sync-code.log --subject "Code Syncing Failure - $error_line: $error_command"
 }
 trap handle_failure ERR
@@ -24,7 +27,5 @@ pkill -f gunicorn || :
 ./Automation/auto-pull.exp -d
 
 # relaunch dash app
-gunicorn app:server -b :8000 >/dev/null 2>./Automation/dash.log &
-sleep 3
-pgrep gunicorn && lsof -i :8000
+./Automation/start_server.sh
 aws sns publish --topic-arn arn:aws:sns:us-east-2:637423600104:Armchair-Strategist --message file://./Automation/sync-code.log --subject "Code Syncing Success - $UTC"

--- a/Automation/test-server.sh
+++ b/Automation/test-server.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if ! lsof -i :8000
+then
+    UTC=$(date)
+    bash ~/Armchair-Strategist/Automation/start_server.sh
+    aws sns publish --topic-arn arn:aws:sns:us-east-2:637423600104:Armchair-Strategist --message "WARNING: The server had been stopped in the past hour" --subject "Server Health Warning - $UTC"
+fi


### PR DESCRIPTION
1. The gunicorn server is currently stopped if any exception occurs during automated jobs. In most cases it is safe to restart the server with older data
2. In case that something unexpected happen and the server is stopped, it is useful to periodically check and restart the server.