### PR TITLE
Use new plotting API in Fastf1 3.4.0

### DIFF
--- a/readme_machine.py
+++ b/readme_machine.py
@@ -223,7 +223,7 @@ def main(
         .sort_values()
         .index
     )
-    team_palette = {team: p.team_color(team) for team in team_order}
+    team_palette = {team: p.get_team_color(team, session=session) for team in team_order}
 
     _, ax = plt.subplots(figsize=(15, 10))
     sns.boxplot(

--- a/readme_machine.py
+++ b/readme_machine.py
@@ -211,7 +211,7 @@ def main(
 
     # use basic fastf1 to make team pace comparison plot
     logger.info("Making team pace comparison graph...")
-    p.setup_mpl(misc_mpl_mods=False)
+    p.setup_mpl()
 
     laps = session.laps.pick_wo_box().pick_track_status("467", how="none")
 


### PR DESCRIPTION
See all changes at theOehrly/Fast-F1#585

- [x] Build on [#92dc891
](https://github.com/Casper-Guo/Armchair-Strategist/commit/92dc891203ac475d22a5404db089fbc05024c659) and restrict Fastf1 to 3.4.0 and above (done by #111)

Graphs that need fixing:

- [x] Dashboard lineplot
- [x] ~Dashboard distplot~ (No good option for differentiating the drivers. The violin/box border lines are not sufficiently flexible. Going to leave this one to just the legends)
- [x] README lineplot
- [x] README scatterplot
- [x] README distplot