### PR TITLE
Explicitly cast to int in range constructions

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,7 +83,7 @@ def configure_lap_numbers_slider(data: dict) -> tuple[int, list[int], dict[int, 
         df = pd.DataFrame.from_dict(data)
         num_laps = df["LapNumber"].max()
 
-    marks = {i: str(i) for i in [1] + list(range(5, num_laps + 1, 5))}
+    marks = {i: str(i) for i in [1] + list(range(5, int(num_laps + 1), 5))}
     return num_laps, [1, num_laps], marks
 
 

--- a/f1_visualization/plotly_dash/graphs.py
+++ b/f1_visualization/plotly_dash/graphs.py
@@ -117,7 +117,7 @@ def strategy_barplot(
         template="plotly_dark",
         xaxis={
             "tickmode": "array",
-            "tickvals": list(range(5, num_laps, 5)),
+            "tickvals": list(range(5, int(num_laps), 5)),
             "title": "Lap Number",
         },
         yaxis={"type": "category"},
@@ -231,7 +231,7 @@ def stats_lineplot(
         template="plotly_dark",
         xaxis={
             "tickmode": "array",
-            "tickvals": list(range(5, num_laps, 5)),
+            "tickvals": list(range(5, int(num_laps), 5)),
             "title": "Lap Number",
         },
         yaxis_title=y,
@@ -332,7 +332,7 @@ def compounds_lineplot(included_laps: pd.DataFrame, y: str, compounds: list[str]
         template="plotly_dark",
         xaxis={
             "tickmode": "array",
-            "tickvals": list(range(5, max_stint_length, 5)),
+            "tickvals": list(range(5, int(max_stint_length), 5)),
             "title": "Tyre Age",
         },
         yaxis_title=yaxis_title,


### PR DESCRIPTION
A float value may be passed to range() if it is calculated from the `LapNumber` or `TyreLife` column since those columns have float type

Fixes #97 