### PR TITLE
Update Fastf1 to 3.4.0 to make 2022 data available

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 """Dash app layout and callbacks."""
 
+import warnings
 from collections import Counter
 from pathlib import Path
 from typing import Iterable, TypeAlias
@@ -18,6 +19,9 @@ from f1_visualization.visualization import get_session_info, load_laps
 
 # Silent SettingWithCopyWarning
 pd.options.mode.chained_assignment = None
+
+# Silent Fastf1 FutureWarning regarding the use of plotting functions
+warnings.filterwarnings(action="ignore", message="Driver", category=FutureWarning)
 
 Session_info: TypeAlias = tuple[int, str, list[str]]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "Transformed data and visualization tools for all Formula 1 races 
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "fastf1 >= 3.3.0, < 3.4.0",
+    "fastf1 >= 3.4.0",
     "pandas >= 1.5.0",
     "matplotlib >= 3.7.0",
     "numpy >= 1.26.0, < 2.0.0",


### PR DESCRIPTION
Suppress Fastf1 plotting module FutureWarnings

Revert the warning filter once #71 is merged