### PR TITLE
Change add_rep data merge type, rerun Sao Paulo GP data processing

### DIFF
--- a/f1_visualization/preprocess.py
+++ b/f1_visualization/preprocess.py
@@ -472,6 +472,7 @@ def add_rep_deltas(df_laps: pd.DataFrame) -> pd.DataFrame:
     )
     df_laps = df_laps.merge(
         rep_times,
+        how="left",
         on="RoundNumber",
         suffixes=(None, "_Rep"),
         validate="many_to_one",


### PR DESCRIPTION
The Sau Paulo GP earlier today revealed an edge case where none of the laps were ran on a slick tyre. All laps thus have `IsValid=False`.

```
  rep_times = (
      df_laps[df_laps["IsValid"]].groupby("RoundNumber")["LapTime"].median().round(decimals=3)
  )
  df_laps = df_laps.merge(
      rep_times,
      on="RoundNumber",
      suffixes=(None, "_Rep"),
      validate="many_to_one",
  )
```

Consequently, `rep_times` is an empty dataframe. `pd.merge` uses inner merge by default and this causes `df_laps` to be set to an empty dataframe as well.

The fix implemented here is to specify left merge instead of inner merge. New implementation is reconciled against the old Mexico GP data.