### PR TITLE
Enable some more ruff rules

### DIFF
--- a/f1_visualization/_consts.py
+++ b/f1_visualization/_consts.py
@@ -6,7 +6,7 @@ import tomli
 ROOT_PATH = Path(__file__).absolute().parents[1]
 DATA_PATH = ROOT_PATH / "Data"
 
-CURRENT_SEASON = datetime.now().year
+CURRENT_SEASON = datetime.now().year  # noqa: DTZ005
 
 # Number of completed rounds in the current season is computed dynamically
 # Calculating this from fastf1 event schedule is non-trivial due to cancelled races
@@ -15,7 +15,7 @@ NUM_ROUNDS = {2018: 21, 2019: 21, 2020: 17, 2021: 22, 2022: 22, 2023: 22}
 # Map session ids to full session names, and reverse
 SESSION_IDS = {"R": "grand_prix", "S": "sprint"}
 SESSION_NAMES = {name: session_id for session_id, name in SESSION_IDS.items()}
-SPRINT_FORMATS = set(("sprint", "sprint_shootout", "sprint_qualifying"))
+SPRINT_FORMATS = {"sprint", "sprint_shootout", "sprint_qualifying"}
 
 with open(DATA_PATH / "compound_selection.toml", "rb") as toml:
     COMPOUND_SELECTION = tomli.load(toml)

--- a/f1_visualization/preprocess.py
+++ b/f1_visualization/preprocess.py
@@ -35,7 +35,7 @@ def get_sprint_rounds(season: int) -> set[int]:
 
 
 class OutdatedTOMLError(Exception):  # noqa: N801
-    """Raised when Data/compound_selection.toml is not up to date."""  # noqa: D203
+    """Raised when Data/compound_selection.toml is not up to date."""
 
 
 def get_session(
@@ -124,8 +124,7 @@ def update_data(season: int, path: Path, session_type: str, sprint_rounds: dict[
     if session_type == "S":
         all_rounds = sprint_rounds[season].intersection(all_rounds)
 
-    missing_rounds = all_rounds.difference(loaded_rounds)
-    missing_rounds = sorted(list(missing_rounds))
+    missing_rounds = sorted(all_rounds.difference(loaded_rounds))
 
     if not missing_rounds:
         logger.info("%d season is already up to date.", season)
@@ -376,7 +375,7 @@ def add_compound_name(
                 row.loc["RoundNumber"],
             )
 
-            raise OutdatedTOMLError
+            raise OutdatedTOMLError from KeyError
 
     df_laps["CompoundName"] = df_laps.apply(convert_compound_name, axis=1)
 

--- a/f1_visualization/visualization.py
+++ b/f1_visualization/visualization.py
@@ -351,7 +351,7 @@ def _teammate_comp_order(included_laps: pd.DataFrame, drivers: list[str], by: st
         else:
             for driver in teammates:
                 if driver in drivers_to_plot:
-                    team_median_gaps.append([tuple([driver]), 0])
+                    team_median_gaps.append([tuple(driver), 0])
                 else:
                     logger.warning(
                         "%s has less than 5 laps of data and will not be plotted",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,18 +61,34 @@ select = [
     "D404",
     # flake8-blind-except
     "BLE",
+    # flake8-bugbear
+    "B",
     # flake8-builtins
     "A",
+    # flake8-comprehensions
+    "C4",
+    # flake8-datetimez
+    "DTZ",
+    # flake8-implicit-str-concat
+    "ISC",
+    # flake8-import-conventions
+    "ICN",
+    # flake8-logging
+    "LOG",
     # flake8-logging-format
     "G",
     # flake8-print
     "T20",
+    # flake8-quotes
+    "Q",
     # flake8-raise
     "RSE",
     # flake8-return
     "RET",
     # flake8-simplify
     "SIM",
+    # flake8-unused-arguments
+    "ARG",
     # flake8-use-pathlib
     "PTH",
     # eradicate
@@ -83,4 +99,10 @@ select = [
     "NPY",
 ]
 
-ignore = ["D211", "D212", "PD901", "PTH123"]
+ignore = [
+    "D203",   # conflict with preferred D211 (No blank lines allowed before class docstring)
+    "D212",   # conflict with preferred D213 (Multi-line docstring summary should start at the second line)
+    "PD901",  # df is a perfectly fine variable name
+    "B905",   # more investigation needed
+    "PTH123", # all open calls already uses Pathlib for file handling
+]


### PR DESCRIPTION
Resolves #122 

Some rulesets that were considered but not added:

- pyupgrade (UP): too many false positives
- flake8-boolean-trap (FBT): too strict
- flake8-commas (COM): already handled by formatter
- flake8-errmsg (EM): conflict with other rules