### PR TITLE
Revert 2025 season temp fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -123,6 +123,19 @@ app.layout = app_layout
 
 
 @callback(
+    Output("season", "options"),
+    # a hack because all Dash callbacks require inputs
+    # no other callbacks modify this value so we expect
+    # this callback to be fired only once on initialization
+    Input("season", "placeholder"),
+)
+def set_season_options(_: str) -> list[int]:
+    """Get the list of seasons with available data."""
+    # dictionaries keys are returned in an unknown order
+    return sorted(DF_DICT.keys(), reverse=True)
+
+
+@callback(
     Output("event", "options"),
     Output("event", "value"),
     Output("event-schedule", "data"),
@@ -139,7 +152,8 @@ def set_event_options(
     schedule = f.get_event_schedule(season, include_testing=False)
 
     if season == CURRENT_SEASON:
-        # only include events for which we have processed data
+        # Do not have to worry about a keyerror here because a season
+        # can only be chosen from the dropdown if it is a key in DF_DICT
         last_round = DF_DICT[CURRENT_SEASON]["R"]["RoundNumber"].max()
         schedule = schedule[schedule["RoundNumber"] <= last_round]
 

--- a/f1_visualization/_consts.py
+++ b/f1_visualization/_consts.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 
 import tomli
@@ -5,7 +6,7 @@ import tomli
 ROOT_PATH = Path(__file__).absolute().parents[1]
 DATA_PATH = ROOT_PATH / "Data"
 
-CURRENT_SEASON = 2024
+CURRENT_SEASON = datetime.now().year  # noqa: DTZ005
 
 # Number of completed rounds in the current season is computed dynamically
 # Calculating this from fastf1 event schedule is non-trivial due to cancelled races

--- a/f1_visualization/plotly_dash/layout.py
+++ b/f1_visualization/plotly_dash/layout.py
@@ -3,8 +3,6 @@
 import dash_bootstrap_components as dbc
 from dash import dcc, html
 
-from f1_visualization._consts import CURRENT_SEASON
-
 
 def upper_bound_slider(slider_id: str, **kwargs) -> dcc.Slider:
     """Generate generic slider for setting upper bound."""
@@ -30,7 +28,7 @@ session_picker_row = dbc.Row(
     [
         dbc.Col(
             dcc.Dropdown(
-                options=list(range(CURRENT_SEASON, 2017, -1)),
+                options=[],
                 placeholder="Select a season",
                 value=None,
                 id="season",


### PR DESCRIPTION
Reverts #123 

`CURRENT_SEASON` will continue to be inferred from the current year. Move year dropdown options out of the static layout file and into a callback so only seasons with available data can be selected

This avoids the possibility of a user selecting the season and then seeing the blank session dropdown

