### PR TITLE
Remove median_only argument in Pandas median

### DIFF
--- a/f1_visualization/plotly_dash/graphs.py
+++ b/f1_visualization/plotly_dash/graphs.py
@@ -309,7 +309,7 @@ def compounds_lineplot(included_laps: pd.DataFrame, y: str, compounds: list[str]
         # use the max instead of the length because tyre life range is
         # not guaranteed to start at 0
         max_stint_length = max(max_stint_length, tyre_life_range.max())
-        median_LRT = compound_laps.groupby("TyreLife")[y].median(numeric_only=True)  # noqa: N806
+        median_LRT = compound_laps.groupby("TyreLife")[y].median()  # noqa: N806
         median_LRT = median_LRT.loc[tyre_life_range]  # noqa: N806
 
         fig.add_trace(

--- a/f1_visualization/readme_machine.py
+++ b/f1_visualization/readme_machine.py
@@ -161,8 +161,8 @@ def main(season: int, round_number: int, grand_prix: bool, update_readme: bool):
     laps["LapTime (s)"] = laps["LapTime"].dt.total_seconds()
     team_order = (
         laps[["Team", "LapTime (s)"]]
-        .groupby("Team")
-        .median(numeric_only=True)["LapTime (s)"]
+        .groupby("Team")["LapTime (s)"]
+        .median()
         .sort_values()
         .index
     )

--- a/f1_visualization/visualization.py
+++ b/f1_visualization/visualization.py
@@ -353,7 +353,7 @@ def teammate_comp_order(
           with teammate_comp=True argument)
         - by is a column in included_laps.
     """
-    metric_median = included_laps.groupby("Driver").median(numeric_only=True)[by]
+    metric_median = included_laps.groupby("Driver")[by].median(numeric_only=True)
     laps_recorded = included_laps.groupby("Driver").size()
     drivers_to_plot = laps_recorded.loc[lambda x: x > 5].index
     team_median_gaps = []


### PR DESCRIPTION
Closes #138 

The bug is caused by passing the `median_only=True` argument to `pd.Series.median`. The doc says it is not implemented but it does have effects. In the case of 2021 Belgian GP, we are invoking this method on a series of `NaN`s and it raises.

The argument is removed at places where we know it is only used with numeric columns (usually as a result of input sanitization). This is because the method silently returning `NaN` is preferred to raising.

At places where there is no input sanitization (such as the exposed API of `teammate_comp_order`), the argument is retained so it will raise when the user requests comparison on non-numerical columns.