### PR TITLE
Implement proper separation of concern in `teammate_comp_order`

### DIFF
--- a/f1_visualization/plotly_dash/layout.py
+++ b/f1_visualization/plotly_dash/layout.py
@@ -183,10 +183,21 @@ lineplot_tab = dbc.Tab(
     label="lineplot",
 )
 
+distplot_caveat = dbc.Alert(
+    [
+        html.H4("Caveats", className="alert-heading"),
+        html.P("Only drivers who have completed more than 5 laps are shown."),
+    ],
+    color="info",
+    dismissable=True,
+)
+
 distplot_tab = dbc.Tab(
     dbc.Card(
         dbc.CardBody(
             [
+                distplot_caveat,
+                html.Br(),
                 dbc.Row(
                     dcc.Dropdown(
                         options=[

--- a/f1_visualization/preprocess.py
+++ b/f1_visualization/preprocess.py
@@ -23,7 +23,7 @@ from f1_visualization._consts import (
     VISUAL_CONFIG,
 )
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s\t%(filename)s\t%(message)s")
+logging.basicConfig(level=logging.INFO, format="%(filename)s\t%(levelname)s\t%(message)s")
 logger = logging.getLogger(__name__)
 
 

--- a/f1_visualization/visualization.py
+++ b/f1_visualization/visualization.py
@@ -21,7 +21,7 @@ from f1_visualization._consts import (
 )
 from f1_visualization._types import Figure, Session
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s\t%(filename)s\t%(message)s")
+logging.basicConfig(level=logging.INFO, format="%(filename)s\t%(levelname)s\t%(message)s")
 logger = logging.getLogger(__name__)
 
 

--- a/readme_machine.py
+++ b/readme_machine.py
@@ -17,7 +17,7 @@ import f1_visualization.visualization as viz
 from f1_visualization._consts import CURRENT_SEASON, NUM_ROUNDS, ROOT_PATH, SPRINT_ROUNDS
 from f1_visualization.preprocess import get_last_round
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s\t%(filename)s\t%(message)s")
+logging.basicConfig(level=logging.INFO, format="%(filename)s\t%(levelname)s\t%(message)s")
 logger = logging.getLogger(__name__)
 
 # plotting setup

--- a/reddit_machine.py
+++ b/reddit_machine.py
@@ -8,7 +8,7 @@ import praw
 
 from f1_visualization._consts import ROOT_PATH
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s\t%(filename)s\t%(message)s")
+logging.basicConfig(level=logging.INFO, format="%(filename)s\t%(levelname)s\t%(message)s")
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This PR was originally for fixing a bug in dashboard scatterplot where a driver's abbreviation is incorrectly processed in teammate side-by-side mode:

![image](https://github.com/user-attachments/assets/9ba2f635-2ad5-4b90-8312-4764fab7e3ce)

Previously, the `teammate_comp_order` function has the undocumented side effect of dropping drivers who have less than 5 laps of data. This is now made explicit by handing off to `remove_low_data_drivers`.

Verified both app and README machine behavior are desirable.

Also changes logging format to be in line with Fastf1