### PR TITLE
Check diff

### DIFF
--- a/Data/grand_prix/transformed_grand_prix_laps_2018.csv
+++ b/Data/grand_prix/transformed_grand_prix_laps_2018.csv
@@ -3510,7 +3510,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:21:14.003000,RIC,3,122.845,38.0,2.0,0 days 01:19:29.863000,,False,SOFT,1.0,True,Red Bull Racing,1,5.0,False,4,Azerbaijan Grand Prix,True,ULTRASOFT,False,14.601,13.489,17.696,16.829,15.312,14.239
 0 days 01:22:59.605000,RIC,3,105.602,39.0,2.0,,,False,SOFT,2.0,True,Red Bull Racing,1,5.0,True,4,Azerbaijan Grand Prix,True,ULTRASOFT,True,-2.642,-2.441,0.453,0.431,-1.95,-1.813
 0 days 01:25:29.605000,RIC,3,,40.0,2.0,,,True,SOFT,3.0,True,Red Bull Racing,0,,False,4,Azerbaijan Grand Prix,True,ULTRASOFT,False,,,,,,
-0 days 00:10:10.534000,OCO,31,,0.0,1.0,,,False,SOFT,4.0,False,Force India,24,1.0,False,4,Azerbaijan Grand Prix,True,ULTRASOFT,False,,,,,,
 0 days 00:10:15.808000,VER,33,153.345,1.0,,0 days 00:00:04.180000,,False,UNKNOWN,,True,Red Bull Racing,24,6.0,False,4,Azerbaijan Grand Prix,False,UNKNOWN,False,45.101,41.666,48.196,45.836,-3.992,-2.537
 0 days 00:13:24.477000,VER,33,,2.0,1.0,,,False,MEDIUM,5.0,False,Red Bull Racing,4,5.0,False,4,Azerbaijan Grand Prix,True,SUPERSOFT,False,,,,,,
 0 days 00:15:58.622000,VER,33,,3.0,1.0,,,False,MEDIUM,6.0,False,Red Bull Racing,4,5.0,False,4,Azerbaijan Grand Prix,True,SUPERSOFT,False,,,,,,
@@ -3551,7 +3550,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:20:57.680000,VER,33,109.815,38.0,1.0,,0 days 01:20:56.542000,False,MEDIUM,41.0,False,Red Bull Racing,1,4.0,False,4,Azerbaijan Grand Prix,True,SUPERSOFT,False,1.571,1.451,4.666,4.438,2.282,2.122
 0 days 01:22:59.326000,VER,33,121.646,39.0,2.0,0 days 01:21:16.247000,,False,SOFT,1.0,True,Red Bull Racing,1,4.0,False,4,Azerbaijan Grand Prix,True,ULTRASOFT,False,13.402,12.381,16.497,15.689,14.094,13.104
 0 days 01:25:29.326000,VER,33,,40.0,2.0,,,True,SOFT,2.0,True,Red Bull Racing,0,,False,4,Azerbaijan Grand Prix,True,ULTRASOFT,False,,,,,,
-0 days 00:10:10.534000,SIR,35,,0.0,1.0,,,False,MEDIUM,1.0,True,Williams,24,2.0,False,4,Azerbaijan Grand Prix,True,SUPERSOFT,False,,,,,,
 0 days 00:10:12.386000,HAM,44,149.923,1.0,,0 days 00:00:04.180000,,False,UNKNOWN,,True,Mercedes,24,2.0,False,4,Azerbaijan Grand Prix,False,UNKNOWN,False,41.679,38.505,44.774,42.581,-7.414,-4.712
 0 days 00:13:21.034000,HAM,44,,2.0,1.0,,,False,MEDIUM,6.0,False,Mercedes,4,2.0,False,4,Azerbaijan Grand Prix,True,SUPERSOFT,False,,,,,,
 0 days 00:15:54.463000,HAM,44,,3.0,1.0,,,False,MEDIUM,7.0,False,Mercedes,4,2.0,False,4,Azerbaijan Grand Prix,True,SUPERSOFT,False,,,,,,
@@ -3899,7 +3897,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:47:57.529000,ERI,9,110.531,49.0,5.0,,,False,SOFT,13.0,False,Sauber,2,4.0,True,4,Azerbaijan Grand Prix,True,ULTRASOFT,False,2.287,2.113,5.382,5.118,1.444,1.324
 0 days 01:49:46.808000,ERI,9,109.279,50.0,5.0,,,False,SOFT,14.0,False,Sauber,2,6.0,True,4,Azerbaijan Grand Prix,True,ULTRASOFT,False,1.035,0.956,4.13,3.928,1.613,1.498
 0 days 01:51:34.733000,ERI,9,107.925,51.0,5.0,,,True,SOFT,15.0,False,Sauber,1,7.0,True,4,Azerbaijan Grand Prix,True,ULTRASOFT,True,-0.319,-0.295,2.776,2.64,0.0,0.0
-0 days 00:08:52.647000,GAS,10,,0.0,1.0,,,False,MEDIUM,1.0,True,Toro Rosso,24,2.0,False,5,Spanish Grand Prix,True,SOFT,False,,,,,,
 0 days 00:09:09.598000,PER,11,125.103,1.0,,0 days 00:00:04.447000,,False,UNKNOWN,,True,Force India,24,13.0,False,5,Spanish Grand Prix,False,UNKNOWN,False,42.53,51.506,46.662,59.487,6.424,5.413
 0 days 00:11:44.041000,PER,11,,2.0,1.0,,,False,MEDIUM,1.0,True,Force India,4,14.0,False,5,Spanish Grand Prix,True,SOFT,False,,,,,,
 0 days 00:13:56.757000,PER,11,132.716,3.0,1.0,,,True,MEDIUM,2.0,True,Force India,4,13.0,False,5,Spanish Grand Prix,True,SOFT,False,50.143,60.726,54.275,69.192,-0.378,-0.284
@@ -4268,7 +4265,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:40:10.071000,MAG,20,81.993,63.0,2.0,,,False,HARD,31.0,True,Haas F1 Team,1,6.0,True,5,Spanish Grand Prix,True,MEDIUM,True,-0.58,-0.702,3.552,4.528,0.277,0.339
 0 days 01:41:30.317000,MAG,20,80.246,64.0,2.0,,,True,HARD,32.0,True,Haas F1 Team,1,6.0,True,5,Spanish Grand Prix,True,MEDIUM,True,-2.327,-2.818,1.805,2.301,-0.481,-0.596
 0 days 01:42:52.683000,MAG,20,82.366,65.0,2.0,,,False,HARD,33.0,True,Haas F1 Team,1,6.0,True,5,Spanish Grand Prix,True,MEDIUM,True,-0.207,-0.251,3.925,5.004,1.544,1.91
-0 days 00:08:52.647000,HUL,27,,0.0,1.0,,,False,MEDIUM,1.0,True,Renault,24,3.0,False,5,Spanish Grand Prix,True,SOFT,False,,,,,,
 0 days 00:09:12.052000,HAR,28,131.078,1.0,,0 days 00:00:04.447000,0 days 00:09:12.755000,False,UNKNOWN,,True,Toro Rosso,24,15.0,False,5,Spanish Grand Prix,False,UNKNOWN,False,48.505,58.742,52.637,67.104,12.399,10.448
 0 days 00:11:43.917000,HAR,28,,2.0,1.0,0 days 00:09:35.367000,,False,MEDIUM,1.0,True,Toro Rosso,4,13.0,False,5,Spanish Grand Prix,True,SOFT,False,,,,,,
 0 days 00:13:59.021000,HAR,28,135.104,3.0,1.0,,,True,MEDIUM,2.0,True,Toro Rosso,4,14.0,False,5,Spanish Grand Prix,True,SOFT,False,52.531,63.618,56.663,72.236,2.01,1.51
@@ -4855,7 +4851,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:40:13.444000,BOT,77,80.421,64.0,2.0,,,False,HARD,45.0,True,Mercedes,1,2.0,True,5,Spanish Grand Prix,True,MEDIUM,True,-2.152,-2.606,1.98,2.524,-0.306,-0.379
 0 days 01:41:34.574000,BOT,77,81.13,65.0,2.0,,,False,HARD,46.0,True,Mercedes,1,2.0,True,5,Spanish Grand Prix,True,MEDIUM,True,-1.443,-1.748,2.689,3.428,0.308,0.381
 0 days 01:42:55.052000,BOT,77,80.478,66.0,2.0,,,False,HARD,47.0,True,Mercedes,1,2.0,True,5,Spanish Grand Prix,True,MEDIUM,True,-2.095,-2.537,2.037,2.597,0.0,0.0
-0 days 00:08:52.647000,GRO,8,,0.0,1.0,,,False,MEDIUM,5.0,False,Haas F1 Team,24,1.0,False,5,Spanish Grand Prix,True,SOFT,False,,,,,,
 0 days 00:09:16.344000,ERI,9,131.849,1.0,,0 days 00:00:04.447000,,False,UNKNOWN,,True,Sauber,24,16.0,False,5,Spanish Grand Prix,False,UNKNOWN,False,49.276,59.676,53.408,68.087,13.17,11.097
 0 days 00:11:46.732000,ERI,9,,2.0,1.0,,,False,HARD,1.0,True,Sauber,4,17.0,False,5,Spanish Grand Prix,True,MEDIUM,False,,,,,,
 0 days 00:14:00.886000,ERI,9,134.154,3.0,1.0,,,True,HARD,2.0,True,Sauber,4,16.0,False,5,Spanish Grand Prix,True,MEDIUM,False,51.581,62.467,55.713,71.025,1.06,0.796
@@ -6684,7 +6679,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:36:07.942000,LEC,16,75.938,67.0,2.0,,,False,HARD,48.0,True,Sauber,1,10.0,True,7,Canadian Grand Prix,True,SUPERSOFT,True,-0.468,-0.613,2.103,2.848,0.069,0.091
 0 days 01:37:23.293000,LEC,16,75.351,68.0,2.0,,,True,HARD,49.0,True,Sauber,1,10.0,True,7,Canadian Grand Prix,True,SUPERSOFT,True,-1.055,-1.381,1.516,2.053,-0.137,-0.181
 0 days 01:38:39.375000,LEC,16,76.082,69.0,2.0,,,False,HARD,50.0,True,Sauber,1,10.0,True,7,Canadian Grand Prix,True,SUPERSOFT,True,-0.324,-0.424,2.247,3.043,0.636,0.843
-0 days 00:08:37.853000,STR,18,,0.0,1.0,,,False,MEDIUM,1.0,True,Williams,24,2.0,False,7,Canadian Grand Prix,True,ULTRASOFT,False,,,,,,
 0 days 00:09:35.301000,VAN,2,159.229,1.0,,0 days 00:00:02.456000,0 days 00:08:56.719000,False,UNKNOWN,,True,McLaren,24,18.0,False,7,Canadian Grand Prix,False,UNKNOWN,False,82.823,108.399,85.394,115.655,44.631,38.946
 0 days 00:11:21.749000,VAN,2,106.448,2.0,2.0,0 days 00:09:37.739000,,False,HARD,1.0,True,McLaren,4,18.0,False,7,Canadian Grand Prix,True,SUPERSOFT,False,30.042,39.319,32.613,44.17,-22.346,-17.35
 0 days 00:13:15.564000,VAN,2,113.815,3.0,2.0,,,True,HARD,2.0,True,McLaren,4,18.0,False,7,Canadian Grand Prix,True,SUPERSOFT,False,37.409,48.961,39.98,54.148,-10.601,-8.521
@@ -6891,7 +6885,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:35:52.397000,HUL,27,76.441,67.0,2.0,,,False,HARD,54.0,True,Renault,1,7.0,True,7,Canadian Grand Prix,True,SUPERSOFT,True,0.035,0.046,2.606,3.529,0.572,0.754
 0 days 01:37:07.885000,HUL,27,75.488,68.0,2.0,,,True,HARD,55.0,True,Renault,1,7.0,True,7,Canadian Grand Prix,True,SUPERSOFT,True,-0.918,-1.201,1.653,2.239,0.0,0.0
 0 days 01:38:24.199000,HUL,27,76.314,69.0,2.0,,,False,HARD,56.0,True,Renault,1,7.0,True,7,Canadian Grand Prix,True,SUPERSOFT,True,-0.092,-0.12,2.479,3.357,0.868,1.15
-0 days 00:08:37.853000,HAR,28,,0.0,1.0,,,False,SOFT,1.0,True,Toro Rosso,24,1.0,False,7,Canadian Grand Prix,True,HYPERSOFT,False,,,,,,
 0 days 00:08:45.372000,RIC,3,108.328,1.0,,0 days 00:00:02.456000,,False,UNKNOWN,,True,Red Bull Racing,24,5.0,False,7,Canadian Grand Prix,False,UNKNOWN,False,31.922,41.779,34.493,46.716,-6.27,-5.471
 0 days 00:10:54.216000,RIC,3,128.844,2.0,1.0,,,True,SOFT,4.0,False,Red Bull Racing,4,5.0,False,7,Canadian Grand Prix,True,HYPERSOFT,False,52.438,68.631,55.009,74.503,0.05,0.039
 0 days 00:12:58.693000,RIC,3,124.477,3.0,1.0,,,True,SOFT,5.0,False,Red Bull Racing,4,5.0,False,7,Canadian Grand Prix,True,HYPERSOFT,False,48.071,62.915,50.642,68.588,0.061,0.049
@@ -7656,7 +7649,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:36:40.200000,ERI,9,76.772,67.0,2.0,,,False,HARD,66.0,True,Sauber,1,15.0,True,7,Canadian Grand Prix,True,SUPERSOFT,True,0.366,0.479,2.937,3.978,0.903,1.19
 0 days 01:37:56.779000,ERI,9,76.579,68.0,2.0,,,False,HARD,67.0,True,Sauber,1,15.0,True,7,Canadian Grand Prix,True,SUPERSOFT,True,0.173,0.226,2.744,3.716,1.091,1.445
 0 days 01:40:26.779000,ERI,9,,69.0,2.0,,,True,HARD,68.0,True,Sauber,0,,False,7,Canadian Grand Prix,True,SUPERSOFT,False,,,,,,
-0 days 00:09:36.099000,GAS,10,,0.0,1.0,,,False,MEDIUM,1.0,True,Toro Rosso,24,2.0,False,8,French Grand Prix,True,SUPERSOFT,False,,,,,,
 0 days 00:09:45.557000,PER,11,138.853,1.0,,0 days 00:00:08.014000,,False,UNKNOWN,,True,Force India,24,9.0,False,8,French Grand Prix,False,UNKNOWN,False,40.589,41.306,44.628,47.363,-0.965,-0.69
 0 days 00:12:26.368000,PER,11,,2.0,1.0,,,False,HARD,1.0,True,Force India,4,11.0,False,8,French Grand Prix,True,SOFT,False,,,,,,
 0 days 00:14:53.945000,PER,11,147.577,3.0,1.0,,,True,HARD,2.0,True,Force India,4,11.0,False,8,French Grand Prix,True,SOFT,False,49.313,50.184,53.352,56.622,-1.095,-0.737
@@ -8101,7 +8093,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:34:27.295000,RIC,3,111.395,51.0,2.0,,,False,HARD,23.0,True,Red Bull Racing,26,4.0,False,8,French Grand Prix,True,SOFT,False,13.131,13.363,17.17,18.222,-11.839,-9.607
 0 days 01:36:32.899000,RIC,3,125.604,52.0,2.0,,,False,HARD,24.0,True,Red Bull Racing,672,4.0,False,8,French Grand Prix,True,SOFT,False,27.34,27.823,31.379,33.302,13.612,12.154
 0 days 01:38:12.839000,RIC,3,99.94,53.0,2.0,,,False,HARD,25.0,True,Red Bull Racing,2,4.0,True,8,French Grand Prix,True,SOFT,False,1.676,1.706,5.715,6.065,2.426,2.488
-0 days 00:09:36.099000,OCO,31,,0.0,1.0,,,False,SOFT,1.0,True,Force India,24,1.0,False,8,French Grand Prix,True,ULTRASOFT,False,,,,,,
 0 days 00:09:37.656000,VER,33,130.952,1.0,,0 days 00:00:08.014000,,False,UNKNOWN,,True,Red Bull Racing,24,2.0,False,8,French Grand Prix,False,UNKNOWN,False,32.688,33.265,36.727,38.978,-8.866,-6.341
 0 days 00:12:16.382000,VER,33,,2.0,1.0,,,False,MEDIUM,4.0,False,Red Bull Racing,4,3.0,False,8,French Grand Prix,True,SUPERSOFT,False,,,,,,
 0 days 00:14:45.288000,VER,33,148.906,3.0,1.0,,,True,MEDIUM,5.0,False,Red Bull Racing,4,3.0,False,8,French Grand Prix,True,SUPERSOFT,False,50.642,51.537,54.681,58.032,0.234,0.157
@@ -12182,7 +12173,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:42:10.112000,ALO,14,85.342,67.0,2.0,,,False,HARD,28.0,True,McLaren,1,8.0,True,12,Hungarian Grand Prix,True,MEDIUM,True,1.413,1.684,5.33,6.662,1.534,1.83
 0 days 01:43:32.202000,ALO,14,82.09,68.0,2.0,,,True,HARD,29.0,True,McLaren,1,8.0,True,12,Hungarian Grand Prix,True,MEDIUM,True,-1.839,-2.191,2.078,2.597,-1.304,-1.564
 0 days 01:44:55.483000,ALO,14,83.281,69.0,2.0,,,False,HARD,30.0,True,McLaren,1,8.0,True,12,Hungarian Grand Prix,True,MEDIUM,True,-0.648,-0.772,3.269,4.086,-0.146,-0.175
-0 days 00:08:24.027000,LEC,16,,0.0,1.0,,,False,MEDIUM,1.0,True,Sauber,1,1.0,False,12,Hungarian Grand Prix,True,SOFT,False,,,,,,
 0 days 00:08:37.570000,STR,18,100.248,1.0,,0 days 00:07:09.557000,0 days 00:06:08.909000,False,UNKNOWN,,True,Williams,1,19.0,False,12,Hungarian Grand Prix,False,UNKNOWN,False,16.319,19.444,20.236,25.291,5.635,5.956
 0 days 00:10:05.619000,STR,18,88.049,2.0,1.0,,,True,HARD,1.0,True,Williams,1,19.0,True,12,Hungarian Grand Prix,True,MEDIUM,True,4.12,4.909,8.037,10.045,1.322,1.524
 0 days 00:11:33.568000,STR,18,87.949,3.0,1.0,,,True,HARD,2.0,True,Williams,1,19.0,True,12,Hungarian Grand Prix,True,MEDIUM,True,4.02,4.79,7.937,9.92,1.337,1.544
@@ -13897,9 +13887,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 00:33:53.226000,RAI,7,114.32,6.0,2.0,,,True,HARD,5.0,True,Ferrari,1,16.0,True,13,Belgian Grand Prix,True,MEDIUM,True,4.503,4.1,8.034,7.559,1.178,1.041
 0 days 00:35:55.553000,RAI,7,122.327,7.0,2.0,,0 days 00:35:51.921000,False,HARD,6.0,True,Ferrari,1,16.0,False,13,Belgian Grand Prix,True,MEDIUM,False,12.51,11.392,16.041,15.092,9.824,8.732
 0 days 00:38:28.498000,RAI,7,,8.0,3.0,0 days 00:36:26.391000,0 days 00:38:23.994000,False,HARD,7.0,False,Ferrari,1,16.0,False,13,Belgian Grand Prix,True,MEDIUM,False,,,,,,
-0 days 00:21:03.948000,LEC,16,,0.0,1.0,,,False,MEDIUM,1.0,True,Sauber,24,1.0,False,13,Belgian Grand Prix,True,SOFT,False,,,,,,
-0 days 00:21:03.948000,ALO,14,,0.0,1.0,,,False,MEDIUM,1.0,True,McLaren,24,2.0,False,13,Belgian Grand Prix,True,SOFT,False,,,,,,
-0 days 00:21:03.948000,HUL,27,,0.0,1.0,,,False,MEDIUM,1.0,True,Renault,24,3.0,False,13,Belgian Grand Prix,True,SOFT,False,,,,,,
 0 days 00:20:31.013000,GAS,10,120.688,1.0,,0 days 00:00:04.950000,,False,UNKNOWN,,True,Toro Rosso,26,11.0,False,14,Italian Grand Prix,False,UNKNOWN,False,35.15,41.093,38.191,46.294,1.22,1.021
 0 days 00:22:48.384000,GAS,10,137.371,2.0,1.0,,,True,SOFT,4.0,False,Toro Rosso,674,11.0,False,14,Italian Grand Prix,True,SUPERSOFT,False,51.833,60.596,54.874,66.516,-0.136,-0.099
 0 days 00:24:49.395000,GAS,10,121.011,3.0,1.0,,,True,SOFT,5.0,False,Toro Rosso,4,11.0,False,14,Italian Grand Prix,True,SUPERSOFT,False,35.473,41.47,38.514,46.685,-0.72,-0.591
@@ -14274,7 +14261,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:32:56.025000,HUL,27,84.315,50.0,3.0,,,False,SOFT,9.0,True,Renault,1,13.0,True,14,Italian Grand Prix,True,SUPERSOFT,True,-1.223,-1.43,1.818,2.204,-0.191,-0.226
 0 days 01:34:20.558000,HUL,27,84.533,51.0,3.0,,,False,SOFT,10.0,True,Renault,1,13.0,True,14,Italian Grand Prix,True,SUPERSOFT,True,-1.005,-1.175,2.036,2.468,-0.232,-0.274
 0 days 01:35:45.545000,HUL,27,84.987,52.0,3.0,,,False,SOFT,11.0,True,Renault,1,13.0,True,14,Italian Grand Prix,True,SUPERSOFT,True,-0.551,-0.644,2.49,3.018,0.483,0.572
-0 days 00:20:17.350000,HAR,28,,0.0,1.0,,,False,SOFT,1.0,True,Toro Rosso,26,1.0,False,14,Italian Grand Prix,True,SUPERSOFT,False,,,,,,
 0 days 00:20:35.878000,RIC,3,128.859,1.0,,0 days 00:00:04.950000,0 days 00:20:35.353000,False,UNKNOWN,,True,Red Bull Racing,26,16.0,False,14,Italian Grand Prix,False,UNKNOWN,False,43.321,50.645,46.362,56.198,9.391,7.861
 0 days 00:22:54.326000,RIC,3,138.448,2.0,4.0,0 days 00:21:00.201000,,False,SOFT,1.0,True,Red Bull Racing,674,16.0,False,14,Italian Grand Prix,True,SUPERSOFT,False,52.91,61.856,55.951,67.822,0.941,0.684
 0 days 00:24:52.561000,RIC,3,118.235,3.0,4.0,,,True,SOFT,2.0,True,Red Bull Racing,4,15.0,False,14,Italian Grand Prix,True,SUPERSOFT,False,32.697,38.225,35.738,43.32,-3.496,-2.872
@@ -15972,7 +15958,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:07:14.212000,SIR,35,108.406,57.0,2.0,,,False,HARD,54.0,True,Williams,1,19.0,True,15,Singapore Grand Prix,True,SOFT,True,1.216,1.134,6.501,6.379,1.665,1.56
 0 days 02:09:09.621000,SIR,35,115.409,58.0,2.0,,,False,HARD,55.0,True,Williams,1,19.0,True,15,Singapore Grand Prix,True,SOFT,True,8.219,7.668,13.504,13.252,8.696,8.149
 0 days 02:11:06.319000,SIR,35,116.698,59.0,3.0,,,False,SOFT,1.0,True,Williams,1,19.0,True,15,Singapore Grand Prix,True,HYPERSOFT,True,9.508,8.87,14.793,14.516,9.926,9.296
-0 days 00:20:58.910000,OCO,31,,0.0,1.0,,,False,SOFT,4.0,False,Racing Point,24,1.0,False,15,Singapore Grand Prix,True,HYPERSOFT,False,,,,,,
 0 days 00:20:15.567000,HAM,44,101.711,1.0,,0 days 00:00:05.591000,,False,UNKNOWN,,True,Mercedes,2,2.0,False,16,Russian Grand Prix,False,UNKNOWN,False,1.449,1.445,5.85,6.103,-7.819,-7.139
 0 days 00:21:55.699000,HAM,44,100.132,2.0,1.0,,,True,MEDIUM,4.0,False,Mercedes,1,2.0,True,16,Russian Grand Prix,True,ULTRASOFT,True,-0.13,-0.13,4.271,4.455,-4.156,-3.985
 0 days 00:23:35.615000,HAM,44,99.916,3.0,1.0,,,True,MEDIUM,5.0,False,Mercedes,1,2.0,True,16,Russian Grand Prix,True,ULTRASOFT,True,-0.346,-0.345,4.055,4.23,-3.026,-2.94
@@ -21766,7 +21751,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:10:13.958000,MAG,20,103.4,52.0,2.0,,,True,MEDIUM,11.0,True,Haas F1 Team,1,10.0,True,21,Abu Dhabi Grand Prix,True,ULTRASOFT,True,-1.711,-1.628,2.533,2.511,0.093,0.09
 0 days 02:11:56.780000,MAG,20,102.822,53.0,2.0,,,True,MEDIUM,12.0,True,Haas F1 Team,1,10.0,True,21,Abu Dhabi Grand Prix,True,ULTRASOFT,True,-2.289,-2.178,1.955,1.938,0.0,0.0
 0 days 02:13:40.248000,MAG,20,103.468,54.0,2.0,,,False,MEDIUM,13.0,True,Haas F1 Team,1,10.0,True,21,Abu Dhabi Grand Prix,True,ULTRASOFT,True,-1.643,-1.563,2.601,2.579,0.273,0.265
-0 days 00:35:49.356000,HUL,27,,0.0,1.0,,,False,SOFT,4.0,False,Renault,24,1.0,False,21,Abu Dhabi Grand Prix,True,HYPERSOFT,False,,,,,,
 0 days 00:36:19.904000,HAR,28,167.566,1.0,1.0,0 days 00:00:03.172000,0 days 00:36:21.169000,False,MEDIUM,1.0,False,Toro Rosso,24,17.0,False,21,Abu Dhabi Grand Prix,True,ULTRASOFT,False,62.455,59.418,66.699,66.126,13.63,8.854
 0 days 00:38:59.209000,HAR,28,,2.0,1.0,0 days 00:37:02.174000,,False,MEDIUM,2.0,False,Toro Rosso,4,17.0,False,21,Abu Dhabi Grand Prix,True,ULTRASOFT,False,,,,,,
 0 days 00:41:36.741000,HAR,28,,3.0,2.0,,,False,HARD,1.0,True,Toro Rosso,4,19.0,False,21,Abu Dhabi Grand Prix,True,SUPERSOFT,False,,,,,,

--- a/Data/grand_prix/transformed_grand_prix_laps_2019.csv
+++ b/Data/grand_prix/transformed_grand_prix_laps_2019.csv
@@ -14359,7 +14359,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:53:35.771000,RIC,3,115.168,41.0,2.0,,,False,MEDIUM,40.0,True,Renault,1,13.0,True,13,Belgian Grand Prix,True,C2,True,4.847,4.394,8.759,8.231,5.864,5.365
 0 days 01:55:33.335000,RIC,3,117.564,42.0,2.0,,,False,MEDIUM,41.0,True,Renault,1,15.0,True,13,Belgian Grand Prix,True,C2,True,7.243,6.565,11.155,10.483,8.337,7.633
 0 days 01:57:31.897000,RIC,3,118.562,43.0,2.0,,,False,MEDIUM,42.0,True,Renault,1,14.0,True,13,Belgian Grand Prix,True,C2,True,8.241,7.47,12.153,11.421,8.804,8.021
-0 days 00:35:44.615000,VER,33,,0.0,1.0,,,False,SOFT,4.0,False,Red Bull Racing,24,1.0,False,13,Belgian Grand Prix,True,C3,False,,,,,,
 0 days 00:35:52.564000,NOR,4,145.499,1.0,1.0,0 days 00:00:07.751000,,False,SOFT,1.0,True,McLaren,24,5.0,False,13,Belgian Grand Prix,True,C3,False,35.178,31.887,39.09,36.736,-8.017,-5.222
 0 days 00:38:50.327000,NOR,4,,2.0,1.0,,,False,SOFT,2.0,True,McLaren,4,5.0,False,13,Belgian Grand Prix,True,C3,False,,,,,,
 0 days 00:41:50.084000,NOR,4,,3.0,1.0,,,False,SOFT,3.0,True,McLaren,4,5.0,False,13,Belgian Grand Prix,True,C3,False,,,,,,
@@ -17808,7 +17807,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:13:32.941000,RIC,3,101.284,22.0,2.0,,,True,MEDIUM,21.0,False,Renault,1,14.0,True,16,Russian Grand Prix,True,C3,True,1.306,1.306,5.523,5.767,0.495,0.491
 0 days 01:15:14.598000,RIC,3,101.657,23.0,2.0,,,False,MEDIUM,22.0,False,Renault,1,14.0,True,16,Russian Grand Prix,True,C3,True,1.679,1.679,5.896,6.157,0.695,0.688
 0 days 01:17:02.803000,RIC,3,108.205,24.0,2.0,,0 days 01:17:01.203000,False,MEDIUM,23.0,False,Renault,1,16.0,False,16,Russian Grand Prix,True,C3,False,8.227,8.229,12.444,12.995,7.397,7.338
-0 days 00:35:33.022000,GRO,8,,0.0,1.0,,,False,SOFT,4.0,False,Haas F1 Team,24,1.0,False,16,Russian Grand Prix,True,C4,False,,,,,,
 0 days 00:35:14.981000,GAS,10,101.359,1.0,1.0,0 days 00:00:05.041000,,False,SOFT,4.0,False,Toro Rosso,1,8.0,False,17,Japanese Grand Prix,True,C3,False,5.381,5.606,10.376,11.404,-1.121,-1.094
 0 days 00:36:52.055000,GAS,10,97.074,2.0,1.0,,,True,SOFT,5.0,False,Toro Rosso,1,8.0,True,17,Japanese Grand Prix,True,C3,True,1.096,1.142,6.091,6.695,-0.376,-0.386
 0 days 00:38:28.736000,GAS,10,96.681,3.0,1.0,,,True,SOFT,6.0,False,Toro Rosso,1,8.0,True,17,Japanese Grand Prix,True,C3,True,0.703,0.732,5.698,6.263,-0.36,-0.371

--- a/Data/grand_prix/transformed_grand_prix_laps_2020.csv
+++ b/Data/grand_prix/transformed_grand_prix_laps_2020.csv
@@ -3825,7 +3825,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 00:52:22.932000,KVY,26,93.461,10.0,1.0,,,False,MEDIUM,10.0,True,AlphaTauri,1,13.0,True,4,British Grand Prix,True,C2,True,2.06,2.254,6.364,7.307,0.289,0.31
 0 days 00:53:55.375000,KVY,26,92.443,11.0,1.0,,,True,MEDIUM,11.0,True,AlphaTauri,1,12.0,True,4,British Grand Prix,True,C2,True,1.042,1.14,5.346,6.138,-0.351,-0.378
 0 days 00:56:25.375000,KVY,26,,12.0,1.0,,,True,MEDIUM,12.0,True,AlphaTauri,0,,False,4,British Grand Prix,True,C2,False,,,,,,
-0 days 00:34:56.925000,HUL,27,,0.0,1.0,,,False,HARD,1.0,True,Racing Point,1,1.0,False,4,British Grand Prix,True,C1,False,,,,,,
 0 days 00:35:02.179000,RIC,3,99.264,1.0,1.0,0 days 00:00:07.305000,,False,SOFT,4.0,False,Renault,1,6.0,False,4,British Grand Prix,True,C3,False,7.863,8.603,12.167,13.969,-2.111,-2.082
 0 days 00:37:11.066000,RIC,3,128.887,2.0,1.0,,,True,SOFT,5.0,False,Renault,24,6.0,False,4,British Grand Prix,True,C3,False,37.486,41.013,41.79,47.981,-2.751,-2.09
 0 days 00:39:40.048000,RIC,3,148.982,3.0,1.0,,,False,SOFT,6.0,False,Renault,4,6.0,False,4,British Grand Prix,True,C3,False,57.581,62.998,61.885,71.053,-0.265,-0.178
@@ -7372,7 +7371,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:55:21.397000,VET,5,111.509,42.0,2.0,,,False,HARD,31.0,True,Ferrari,1,13.0,True,7,Belgian Grand Prix,True,C2,True,1.18,1.07,4.026,3.746,1.28,1.161
 0 days 01:57:12.182000,VET,5,110.785,43.0,2.0,,,False,HARD,32.0,True,Ferrari,1,13.0,True,7,Belgian Grand Prix,True,C2,True,0.456,0.413,3.302,3.072,0.611,0.555
 0 days 01:59:03.567000,VET,5,111.385,44.0,2.0,,,False,HARD,33.0,True,Ferrari,2,13.0,True,7,Belgian Grand Prix,True,C2,False,1.056,0.957,3.902,3.63,0.655,0.592
-0 days 00:35:34.242000,SAI,55,,0.0,1.0,,,False,SOFT,4.0,False,McLaren,1,1.0,False,7,Belgian Grand Prix,True,C4,False,,,,,,
 0 days 00:35:46.579000,LAT,6,124.659,1.0,1.0,0 days 00:00:06.179000,,False,MEDIUM,1.0,True,Williams,1,19.0,False,7,Belgian Grand Prix,True,C3,False,14.33,12.988,17.176,15.98,5.358,4.491
 0 days 00:37:41.427000,LAT,6,114.848,2.0,1.0,,,True,MEDIUM,2.0,True,Williams,1,19.0,True,7,Belgian Grand Prix,True,C3,True,4.519,4.096,7.365,6.852,1.231,1.083
 0 days 00:39:34.892000,LAT,6,113.465,3.0,1.0,,,True,MEDIUM,3.0,True,Williams,1,19.0,True,7,Belgian Grand Prix,True,C3,True,3.136,2.842,5.982,5.566,1.209,1.077
@@ -8495,7 +8493,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 00:39:28.010000,VET,5,87.107,4.0,1.0,,,True,HARD,4.0,True,Ferrari,1,17.0,True,8,Italian Grand Prix,True,C2,True,1.427,1.665,4.361,5.27,0.959,1.113
 0 days 00:40:56.330000,VET,5,88.32,5.0,1.0,,,False,HARD,5.0,True,Ferrari,1,18.0,True,8,Italian Grand Prix,True,C2,True,2.64,3.081,5.574,6.736,2.114,2.452
 0 days 00:43:17.087000,VET,5,140.757,6.0,1.0,,0 days 00:43:09.512000,False,HARD,6.0,True,Ferrari,1,20.0,False,8,Italian Grand Prix,True,C2,False,55.077,64.282,58.011,70.107,54.303,62.811
-0 days 00:35:12.350000,GAS,10,,0.0,1.0,,,False,SOFT,1.0,True,AlphaTauri,24,2.0,False,9,Tuscan Grand Prix,True,C3,False,,,,,,
 0 days 00:35:22.614000,PER,11,117.098,1.0,1.0,0 days 00:00:03.736000,,False,SOFT,4.0,False,Racing Point,24,7.0,False,9,Tuscan Grand Prix,True,C3,False,33.56,40.173,38.265,48.539,-5.818,-4.733
 0 days 00:37:48.003000,PER,11,145.389,2.0,1.0,,,True,SOFT,5.0,False,Racing Point,4,9.0,False,9,Tuscan Grand Prix,True,C3,False,61.851,74.039,66.556,84.427,1.139,0.79
 0 days 00:40:05.196000,PER,11,137.193,3.0,1.0,,,True,SOFT,6.0,False,Racing Point,4,9.0,False,9,Tuscan Grand Prix,True,C3,False,53.655,64.228,58.36,74.03,0.03,0.022
@@ -8848,7 +8845,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 00:46:50.774000,OCO,31,131.793,6.0,1.0,,,True,SOFT,9.0,False,Renault,4,12.0,False,9,Tuscan Grand Prix,True,C3,False,48.255,57.764,52.96,67.18,-4.016,-2.957
 0 days 00:49:04.597000,OCO,31,133.823,7.0,1.0,,0 days 00:48:49.778000,False,SOFT,10.0,False,Renault,24,12.0,False,9,Tuscan Grand Prix,True,C3,False,50.285,60.194,54.99,69.755,3.916,3.014
 0 days 00:51:25.895000,OCO,31,,8.0,2.0,0 days 00:49:07.227000,0 days 00:51:25.902000,False,SOFT,11.0,False,Renault,45,1.0,False,9,Tuscan Grand Prix,True,C3,False,,,,,,
-0 days 00:35:12.350000,VER,33,,0.0,1.0,,,False,SOFT,4.0,False,Red Bull Racing,24,1.0,False,9,Tuscan Grand Prix,True,C3,False,,,,,,
 0 days 00:35:25.452000,NOR,4,119.936,1.0,1.0,0 days 00:00:03.736000,,False,SOFT,1.0,True,McLaren,24,8.0,False,9,Tuscan Grand Prix,True,C3,False,36.398,43.571,41.103,52.139,-2.98,-2.424
 0 days 00:37:49.823000,NOR,4,144.371,2.0,1.0,,,True,SOFT,2.0,True,McLaren,4,10.0,False,9,Tuscan Grand Prix,True,C3,False,60.833,72.821,65.538,83.135,0.121,0.084
 0 days 00:40:07.154000,NOR,4,137.331,3.0,1.0,,,True,SOFT,3.0,True,McLaren,4,10.0,False,9,Tuscan Grand Prix,True,C3,False,53.793,64.393,58.498,74.205,0.168,0.122
@@ -10227,8 +10223,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:05:16.463000,RUS,63,107.257,50.0,3.0,,0 days 02:05:10.094000,False,MEDIUM,38.0,False,Williams,1,18.0,False,10,Russian Grand Prix,True,C4,False,6.157,6.09,10.227,10.54,7.278,7.28
 0 days 02:07:16.903000,RUS,63,120.44,51.0,4.0,0 days 02:05:39.752000,,False,SOFT,1.0,True,Williams,1,18.0,False,10,Russian Grand Prix,True,C5,False,19.34,19.13,23.41,24.127,20.859,20.947
 0 days 02:08:54.255000,RUS,63,97.352,52.0,4.0,,,True,SOFT,2.0,True,Williams,1,18.0,True,10,Russian Grand Prix,True,C5,True,-3.748,-3.707,0.322,0.332,-2.213,-2.223
-0 days 00:35:40.827000,SAI,55,,0.0,1.0,,,False,SOFT,4.0,False,McLaren,24,1.0,False,10,Russian Grand Prix,True,C5,False,,,,,,
-0 days 00:35:40.827000,STR,18,,0.0,1.0,,,False,MEDIUM,1.0,True,Racing Point,24,2.0,False,10,Russian Grand Prix,True,C4,False,,,,,,
 0 days 00:01:44.049000,GAS,10,103.776,1.0,1.0,0 days 00:00:04.888000,,False,MEDIUM,1.0,True,AlphaTauri,1,13.0,False,11,Eifel Grand Prix,True,C3,False,10.957,11.805,15.637,17.741,1.432,1.399
 0 days 00:03:21.960000,GAS,10,97.911,2.0,1.0,,,True,MEDIUM,2.0,True,AlphaTauri,1,14.0,True,11,Eifel Grand Prix,True,C3,True,5.092,5.486,9.772,11.087,1.978,2.062
 0 days 00:04:57.450000,GAS,10,95.49,3.0,1.0,,,True,MEDIUM,3.0,True,AlphaTauri,1,14.0,True,11,Eifel Grand Prix,True,C3,True,2.671,2.878,7.351,8.34,0.595,0.627
@@ -15710,7 +15704,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 03:30:04.685000,BOT,77,131.174,55.0,5.0,,,False,MEDIUM,32.0,False,Mercedes,4,8.0,False,15,Bahrain Grand Prix,True,C3,False,35.54,37.163,39.16,42.559,1.712,1.322
 0 days 03:31:55.892000,BOT,77,111.207,56.0,5.0,,,False,MEDIUM,33.0,False,Mercedes,4,7.0,False,15,Bahrain Grand Prix,True,C3,False,15.573,16.284,19.193,20.859,-11.289,-9.216
 0 days 03:33:43.681000,BOT,77,107.789,57.0,5.0,,,False,MEDIUM,34.0,False,Mercedes,4,7.0,False,15,Bahrain Grand Prix,True,C3,False,12.155,12.71,15.775,17.144,-7.571,-6.563
-0 days 00:35:45.146000,GRO,8,,0.0,1.0,,,False,HARD,1.0,True,Haas F1 Team,5,1.0,False,15,Bahrain Grand Prix,True,C2,False,,,,,,
 0 days 00:36:19.889000,GIO,99,163.748,1.0,1.0,0 days 00:00:03.554000,0 days 00:36:18.739000,False,MEDIUM,1.0,True,Alfa Romeo Racing,5,11.0,False,15,Bahrain Grand Prix,True,C3,False,68.114,71.224,71.734,77.96,3.635,2.27
 0 days 01:58:49.916000,GIO,99,,2.0,2.0,0 days 01:55:33.646000,,False,MEDIUM,1.0,True,Alfa Romeo Racing,1,15.0,False,15,Bahrain Grand Prix,True,C3,False,,,,,,
 0 days 02:01:44.504000,GIO,99,,3.0,2.0,,,False,MEDIUM,2.0,True,Alfa Romeo Racing,24,17.0,False,15,Bahrain Grand Prix,True,C3,False,,,,,,
@@ -15941,7 +15934,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:02:01.611000,PER,11,57.208,85.0,3.0,,,False,HARD,38.0,True,Racing Point,1,1.0,True,16,Sakhir Grand Prix,True,C2,True,-1.258,-2.152,1.804,3.256,-0.305,-0.53
 0 days 02:02:59.015000,PER,11,57.404,86.0,3.0,,,False,HARD,39.0,True,Racing Point,1,1.0,True,16,Sakhir Grand Prix,True,C2,True,-1.062,-1.816,2.0,3.61,-0.117,-0.203
 0 days 02:03:56.258000,PER,11,57.243,87.0,3.0,,,False,HARD,40.0,True,Racing Point,1,1.0,True,16,Sakhir Grand Prix,True,C2,True,-1.223,-2.092,1.839,3.319,-0.561,-0.971
-0 days 00:33:52.706000,LEC,16,,0.0,1.0,,,False,SOFT,4.0,False,Ferrari,24,2.0,False,16,Sakhir Grand Prix,True,C4,False,,,,,,
 0 days 00:34:04.302000,STR,18,80.518,1.0,1.0,0 days 00:00:03.563000,,False,SOFT,4.0,False,Racing Point,24,6.0,False,16,Sakhir Grand Prix,True,C4,False,22.052,37.718,25.114,45.329,-7.429,-8.447
 0 days 00:35:38.921000,STR,18,94.619,2.0,1.0,,,True,SOFT,5.0,False,Racing Point,4,6.0,False,16,Sakhir Grand Prix,True,C4,False,36.153,61.836,39.215,70.78,0.764,0.814
 0 days 00:37:09.310000,STR,18,90.389,3.0,1.0,,,True,SOFT,6.0,False,Racing Point,4,6.0,False,16,Sakhir Grand Prix,True,C4,False,31.923,54.601,34.985,63.145,-0.378,-0.416
@@ -16464,7 +16456,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:02:14.375000,OCO,31,57.546,85.0,2.0,,,False,HARD,44.0,True,Renault,1,2.0,True,16,Sakhir Grand Prix,True,C2,True,-0.92,-1.574,2.142,3.866,0.033,0.057
 0 days 02:03:11.896000,OCO,31,57.521,86.0,2.0,,,False,HARD,45.0,True,Renault,1,2.0,True,16,Sakhir Grand Prix,True,C2,True,-0.945,-1.616,2.117,3.821,0.0,0.0
 0 days 02:04:09.416000,OCO,31,57.52,87.0,2.0,,,False,HARD,46.0,True,Renault,1,2.0,True,16,Sakhir Grand Prix,True,C2,True,-0.946,-1.618,2.116,3.819,-0.284,-0.491
-0 days 00:33:52.706000,VER,33,,0.0,1.0,,,False,SOFT,4.0,False,Red Bull Racing,24,1.0,False,16,Sakhir Grand Prix,True,C4,False,,,,,,
 0 days 00:34:12.888000,NOR,4,89.104,1.0,1.0,0 days 00:00:03.563000,,False,SOFT,1.0,True,McLaren,24,10.0,False,16,Sakhir Grand Prix,True,C4,False,30.638,52.403,33.7,60.826,1.157,1.316
 0 days 00:35:46.086000,NOR,4,93.198,2.0,1.0,,,True,SOFT,2.0,True,McLaren,4,10.0,False,16,Sakhir Grand Prix,True,C4,False,34.732,59.405,37.794,68.215,-0.657,-0.7
 0 days 00:37:17.253000,NOR,4,91.167,3.0,1.0,,,True,SOFT,3.0,True,McLaren,4,10.0,False,16,Sakhir Grand Prix,True,C4,False,32.701,55.932,35.763,64.549,0.4,0.441

--- a/Data/grand_prix/transformed_grand_prix_laps_2021.csv
+++ b/Data/grand_prix/transformed_grand_prix_laps_2021.csv
@@ -971,7 +971,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:06:23.465000,BOT,77,97.802,54.0,3.0,,0 days 02:06:21.738000,False,HARD,24.0,True,Mercedes,1,3.0,False,1,Bahrain Grand Prix,True,C2,False,1.344,1.393,5.712,6.203,1.88,1.96
 0 days 02:08:19.364000,BOT,77,115.899,55.0,4.0,0 days 02:06:46.324000,,False,MEDIUM,4.0,False,Mercedes,1,3.0,False,1,Bahrain Grand Prix,True,C3,False,19.441,20.155,23.809,25.854,19.811,20.618
 0 days 02:09:51.454000,BOT,77,92.09,56.0,4.0,,,True,MEDIUM,5.0,False,Mercedes,1,3.0,True,1,Bahrain Grand Prix,True,C3,True,-4.368,-4.528,0.0,0.0,-3.67,-3.832
-0 days 00:39:08.419000,MAZ,9,,0.0,1.0,,,False,MEDIUM,1.0,True,Haas F1 Team,24,1.0,False,1,Bahrain Grand Prix,True,C3,False,,,,,,
 0 days 00:39:28.536000,GIO,99,138.362,1.0,1.0,0 days 00:00:04.260000,,False,MEDIUM,1.0,True,Alfa Romeo Racing,24,12.0,False,1,Bahrain Grand Prix,True,C3,False,41.904,43.443,46.272,50.246,4.08,3.038
 0 days 00:41:47.415000,GIO,99,138.879,2.0,1.0,,,True,MEDIUM,2.0,True,Alfa Romeo Racing,4,12.0,False,1,Bahrain Grand Prix,True,C3,False,42.421,43.979,46.789,50.808,-0.897,-0.642
 0 days 00:44:12.541000,GIO,99,145.126,3.0,1.0,,,False,MEDIUM,3.0,True,Alfa Romeo Racing,4,12.0,False,1,Bahrain Grand Prix,True,C3,False,48.668,50.455,53.036,57.591,2.496,1.75
@@ -1905,7 +1904,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:33:40.248000,SAI,55,78.571,61.0,3.0,,,False,MEDIUM,34.0,False,Ferrari,2,5.0,True,2,Emilia Romagna Grand Prix,True,C3,False,-1.311,-1.641,1.869,2.437,-1.035,-1.3
 0 days 02:34:59.012000,SAI,55,78.764,62.0,3.0,,,False,MEDIUM,35.0,False,Ferrari,1,5.0,True,2,Emilia Romagna Grand Prix,True,C3,True,-1.118,-1.4,2.062,2.688,-0.48,-0.606
 0 days 02:36:17.508000,SAI,55,78.496,63.0,3.0,,,False,MEDIUM,36.0,False,Ferrari,1,5.0,True,2,Emilia Romagna Grand Prix,True,C3,True,-1.386,-1.735,1.794,2.339,-1.031,-1.296
-0 days 00:34:54.453000,LAT,6,,0.0,1.0,,,False,INTERMEDIATE,1.0,True,Williams,2,1.0,False,2,Emilia Romagna Grand Prix,False,INTERMEDIATE,False,,,,,,
 0 days 00:35:18.480000,RUS,63,122.63,1.0,1.0,0 days 00:00:03.846000,,False,INTERMEDIATE,1.0,True,Williams,24,13.0,False,2,Emilia Romagna Grand Prix,False,INTERMEDIATE,False,42.748,53.514,45.928,59.878,1.738,1.438
 0 days 00:37:42.023000,RUS,63,143.543,2.0,1.0,,,True,INTERMEDIATE,2.0,True,Williams,4,12.0,False,2,Emilia Romagna Grand Prix,False,INTERMEDIATE,False,63.661,79.694,66.841,87.144,0.094,0.066
 0 days 00:40:02.673000,RUS,63,140.65,3.0,1.0,,,True,INTERMEDIATE,3.0,True,Williams,4,12.0,False,2,Emilia Romagna Grand Prix,False,INTERMEDIATE,False,60.768,76.072,63.948,83.372,0.0,0.0
@@ -6065,7 +6063,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:08:45.561000,BOT,77,76.034,28.0,1.0,,,False,SOFT,33.0,False,Mercedes,1,2.0,True,5,Monaco Grand Prix,True,C5,True,-0.659,-0.859,3.125,4.286,-1.124,-1.457
 0 days 01:10:01.826000,BOT,77,76.265,29.0,1.0,,,False,SOFT,34.0,False,Mercedes,1,2.0,True,5,Monaco Grand Prix,True,C5,True,-0.428,-0.558,3.356,4.603,-0.802,-1.041
 0 days 01:11:12.236000,BOT,77,,30.0,1.0,,0 days 01:11:12.283000,False,SOFT,35.0,False,Mercedes,1,1.0,False,5,Monaco Grand Prix,True,C5,False,,,,,,
-0 days 00:34:16.815000,LEC,16,,0.0,1.0,,,False,SOFT,5.0,False,Ferrari,1,1.0,False,5,Monaco Grand Prix,True,C5,False,,,,,,
 0 days 00:35:54.977000,GAS,10,115.24,1.0,1.0,0 days 00:00:04.563000,,False,SOFT,6.0,False,AlphaTauri,1,5.0,False,6,Azerbaijan Grand Prix,True,C5,False,7.981,7.441,10.759,10.298,-4.518,-3.773
 0 days 00:37:44.008000,GAS,10,109.031,2.0,1.0,,,True,SOFT,7.0,False,AlphaTauri,1,5.0,True,6,Azerbaijan Grand Prix,True,C5,True,1.772,1.652,4.55,4.355,-1.603,-1.449
 0 days 00:39:33.215000,GAS,10,109.207,3.0,1.0,,,False,SOFT,8.0,False,AlphaTauri,1,5.0,True,6,Azerbaijan Grand Prix,True,C5,True,1.948,1.816,4.726,4.523,-0.216,-0.197
@@ -10694,7 +10691,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:24:24.347000,MAZ,9,70.264,67.0,3.0,,,False,HARD,22.0,True,Haas F1 Team,1,19.0,True,9,Austrian Grand Prix,True,C2,True,0.398,0.57,4.064,6.139,1.218,1.764
 0 days 02:25:34.994000,MAZ,9,70.647,68.0,3.0,,,False,HARD,23.0,True,Haas F1 Team,1,19.0,True,9,Austrian Grand Prix,True,C2,True,0.781,1.118,4.447,6.718,1.472,2.128
 0 days 02:26:47.202000,MAZ,9,72.208,69.0,3.0,,,False,HARD,24.0,True,Haas F1 Team,2,19.0,True,9,Austrian Grand Prix,True,C2,False,2.342,3.352,6.008,9.076,3.226,4.677
-0 days 01:03:23.460000,OCO,31,,0.0,1.0,,,False,MEDIUM,1.0,True,Alpine,4,1.0,False,9,Austrian Grand Prix,True,C3,False,,,,,,
 0 days 01:04:28.484000,HAM,44,125.599,1.0,1.0,0 days 00:24:42.611000,,False,MEDIUM,2.0,False,Mercedes,24,2.0,False,10,British Grand Prix,True,C2,False,32.352,34.695,36.982,41.732,-11.128,-8.139
 0 days 01:07:06.686000,HAM,44,,2.0,1.0,,0 days 01:07:00.518000,False,MEDIUM,3.0,False,Mercedes,45,2.0,False,10,British Grand Prix,True,C2,False,,,,,,
 0 days 01:44:15.822000,HAM,44,,3.0,2.0,0 days 01:41:08.889000,,False,MEDIUM,1.0,False,Mercedes,1,2.0,False,10,British Grand Prix,True,C2,False,,,,,,
@@ -11664,7 +11660,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:40:42.883000,VET,5,93.064,38.0,3.0,,,False,HARD,22.0,False,Aston Martin,1,17.0,True,10,British Grand Prix,True,C1,True,-0.183,-0.196,4.447,5.018,0.07,0.075
 0 days 02:42:16.604000,VET,5,93.721,39.0,3.0,,,False,HARD,23.0,False,Aston Martin,1,17.0,True,10,British Grand Prix,True,C1,True,0.474,0.508,5.104,5.76,0.586,0.629
 0 days 02:43:57.939000,VET,5,101.335,40.0,3.0,,0 days 02:43:52.008000,False,HARD,24.0,False,Aston Martin,1,17.0,False,10,British Grand Prix,True,C1,False,8.088,8.674,12.718,14.352,8.514,9.172
-0 days 01:04:25.585000,VER,33,,0.0,1.0,,,False,MEDIUM,1.0,True,Red Bull Racing,24,1.0,False,10,British Grand Prix,True,C2,False,,,,,,
 0 days 01:04:12.687000,OCO,31,119.634,1.0,1.0,0 days 00:24:47.433000,,False,INTERMEDIATE,1.0,True,Alpine,24,2.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,36.37,43.68,41.24,52.606,-10.481,-8.055
 0 days 01:07:02.342000,OCO,31,,2.0,1.0,,0 days 01:07:00.116000,False,INTERMEDIATE,2.0,True,Alpine,45,2.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,,,,,,
 0 days 01:33:33.161000,OCO,31,,3.0,2.0,0 days 01:31:10.321000,0 days 01:33:31.480000,False,INTERMEDIATE,1.0,True,Alpine,1,1.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,,,,,,
@@ -12576,10 +12571,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:33:50.200000,MAZ,9,,3.0,3.0,0 days 01:31:51.821000,0 days 01:33:47.196000,False,INTERMEDIATE,1.0,True,Haas F1 Team,1,15.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,,,,,,
 0 days 01:04:34.998000,NOR,4,142.425,1.0,1.0,0 days 00:25:22.281000,0 days 01:04:35.352000,False,INTERMEDIATE,1.0,True,McLaren,24,14.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,59.161,71.052,64.031,81.678,12.31,9.461
 0 days 01:07:41.726000,NOR,4,,2.0,2.0,0 days 01:05:11.939000,0 days 01:07:35.720000,False,INTERMEDIATE,1.0,True,McLaren,45,15.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,,,,,,
-0 days 01:04:11.122000,BOT,77,,0.0,1.0,,,False,INTERMEDIATE,1.0,True,Mercedes,24,1.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,,,,,,
-0 days 01:04:11.122000,PER,11,,0.0,1.0,,,False,INTERMEDIATE,1.0,True,Red Bull Racing,24,2.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,,,,,,
-0 days 01:04:11.122000,LEC,16,,0.0,1.0,,,False,INTERMEDIATE,1.0,True,Ferrari,24,3.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,,,,,,
-0 days 01:04:11.122000,STR,18,,0.0,1.0,,,False,INTERMEDIATE,1.0,True,Aston Martin,24,4.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,,,,,,
 0 days 01:04:14.459000,VET,5,121.406,1.0,1.0,0 days 00:23:31.592000,,False,INTERMEDIATE,1.0,True,Aston Martin,24,3.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,38.142,45.809,43.012,54.866,-8.709,-6.693
 0 days 01:07:05.877000,VET,5,,2.0,1.0,,0 days 01:07:03.380000,False,INTERMEDIATE,2.0,True,Aston Martin,45,3.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,,,,,,
 0 days 01:33:33.790000,VET,5,,3.0,2.0,0 days 01:31:14.941000,0 days 01:33:32.100000,False,INTERMEDIATE,1.0,True,Aston Martin,1,2.0,False,11,Hungarian Grand Prix,False,INTERMEDIATE,False,,,,,,
@@ -14286,7 +14277,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:21:33.021000,STR,18,85.929,51.0,2.0,,,False,HARD,28.0,False,Aston Martin,1,7.0,True,14,Italian Grand Prix,True,C2,True,-0.951,-1.095,1.117,1.317,0.001,0.001
 0 days 02:22:58.874000,STR,18,85.853,52.0,2.0,,,True,HARD,29.0,False,Aston Martin,1,7.0,True,14,Italian Grand Prix,True,C2,True,-1.027,-1.182,1.041,1.227,0.0,0.0
 0 days 02:24:24.951000,STR,18,86.077,53.0,2.0,,,False,HARD,30.0,False,Aston Martin,1,7.0,True,14,Italian Grand Prix,True,C2,True,-0.803,-0.924,1.265,1.492,0.511,0.597
-0 days 01:03:52.443000,TSU,22,,0.0,1.0,,,False,MEDIUM,1.0,True,AlphaTauri,26,1.0,False,14,Italian Grand Prix,True,C3,False,,,,,,
 0 days 01:03:52.443000,RIC,3,97.656,1.0,1.0,0 days 00:25:09.902000,,False,MEDIUM,1.0,True,McLaren,26,1.0,False,14,Italian Grand Prix,True,C3,False,10.776,12.403,12.844,15.144,-17.334,-15.074
 0 days 01:05:23.188000,RIC,3,90.745,2.0,1.0,,,True,MEDIUM,2.0,True,McLaren,67,1.0,False,14,Italian Grand Prix,True,C3,False,3.865,4.449,5.933,6.995,2.674,3.036
 0 days 01:06:49.514000,RIC,3,86.326,3.0,1.0,,,True,MEDIUM,3.0,True,McLaren,1,1.0,True,14,Italian Grand Prix,True,C3,True,-0.554,-0.638,1.514,1.785,-0.784,-0.9
@@ -19438,8 +19428,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:38:44.181000,MAZ,9,82.458,66.0,3.0,,,False,MEDIUM,8.0,False,Haas F1 Team,1,18.0,True,18,Mexico City Grand Prix,True,C3,True,0.44,0.536,4.684,6.023,1.254,1.544
 0 days 02:40:07.231000,MAZ,9,83.05,67.0,3.0,,,False,MEDIUM,9.0,False,Haas F1 Team,1,18.0,True,18,Mexico City Grand Prix,True,C3,True,1.032,1.258,5.276,6.784,1.792,2.205
 0 days 02:41:30.015000,MAZ,9,82.784,68.0,3.0,,,False,MEDIUM,10.0,False,Haas F1 Team,1,18.0,True,18,Mexico City Grand Prix,True,C3,True,0.766,0.934,5.01,6.442,1.592,1.961
-0 days 01:03:48.427000,MSC,47,,0.0,1.0,,,False,MEDIUM,1.0,True,Haas F1 Team,24,1.0,False,18,Mexico City Grand Prix,True,C3,False,,,,,,
-0 days 01:03:48.427000,TSU,22,,0.0,1.0,,,False,SOFT,4.0,False,AlphaTauri,24,2.0,False,18,Mexico City Grand Prix,True,C4,False,,,,,,
 0 days 01:03:15.240000,HAM,44,83.099,1.0,1.0,0 days 00:25:37.894000,,False,MEDIUM,1.0,True,Mercedes,1,7.0,False,19,São Paulo Grand Prix,True,C3,False,7.999,10.651,12.089,17.024,-1.743,-2.054
 0 days 01:04:30.915000,HAM,44,75.675,2.0,1.0,,,True,MEDIUM,2.0,True,Mercedes,1,6.0,True,19,São Paulo Grand Prix,True,C3,True,0.575,0.766,4.665,6.569,-1.421,-1.843
 0 days 01:05:45.169000,HAM,44,74.254,3.0,1.0,,,True,MEDIUM,3.0,True,Mercedes,1,5.0,True,19,São Paulo Grand Prix,True,C3,True,-0.846,-1.126,3.244,4.568,-1.945,-2.553

--- a/Data/grand_prix/transformed_grand_prix_laps_2022.csv
+++ b/Data/grand_prix/transformed_grand_prix_laps_2022.csv
@@ -4120,7 +4120,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:11:08.488000,ALO,14,136.968,4.0,1.0,,,True,INTERMEDIATE,4.0,True,Alpine,4,8.0,False,4,Emilia Romagna Grand Prix,False,INTERMEDIATE,False,55.069,67.24,58.522,74.602,3.241,2.424
 0 days 01:12:48.173000,ALO,14,99.685,5.0,1.0,,,True,INTERMEDIATE,5.0,True,Alpine,1,11.0,False,4,Emilia Romagna Grand Prix,False,INTERMEDIATE,False,17.786,21.717,21.239,27.075,2.605,2.683
 0 days 01:14:28.418000,ALO,14,100.245,6.0,1.0,,0 days 01:14:23.967000,False,INTERMEDIATE,6.0,True,Alpine,1,19.0,False,4,Emilia Romagna Grand Prix,False,INTERMEDIATE,False,18.346,22.401,21.799,27.789,6.484,6.915
-0 days 01:03:54.806000,SAI,55,,0.0,1.0,,,False,INTERMEDIATE,1.0,True,Ferrari,24,1.0,False,4,Emilia Romagna Grand Prix,False,INTERMEDIATE,False,,,,,,
 0 days 01:03:53.422000,VER,1,97.528,1.0,1.0,0 days 00:23:51.168000,,False,MEDIUM,1.0,True,Red Bull Racing,1,2.0,False,5,Miami Grand Prix,True,C3,False,2.692,2.839,6.167,6.75,-6.224,-5.999
 0 days 01:05:27.964000,VER,1,94.542,2.0,1.0,,,True,MEDIUM,2.0,True,Red Bull Racing,1,2.0,True,5,Miami Grand Prix,True,C3,True,-0.294,-0.31,3.181,3.482,-2.58,-2.656
 0 days 01:07:02.514000,VER,1,94.55,3.0,1.0,,,False,MEDIUM,3.0,True,Red Bull Racing,1,2.0,True,5,Miami Grand Prix,True,C3,True,-0.286,-0.302,3.189,3.491,-1.765,-1.833
@@ -10132,8 +10131,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 03:17:29.957000,TSU,22,94.191,50.0,4.0,,,False,SOFT,12.0,True,AlphaTauri,1,14.0,True,10,British Grand Prix,True,C3,True,0.007,0.007,3.681,4.067,1.283,1.381
 0 days 03:19:03.789000,TSU,22,93.832,51.0,4.0,,,True,SOFT,13.0,True,AlphaTauri,1,14.0,True,10,British Grand Prix,True,C3,True,-0.352,-0.374,3.322,3.67,1.17,1.263
 0 days 03:20:37.878000,TSU,22,94.089,52.0,4.0,,,False,SOFT,14.0,True,AlphaTauri,1,14.0,True,10,British Grand Prix,True,C3,True,-0.095,-0.101,3.579,3.954,1.664,1.8
-0 days 01:04:38.967000,ALB,23,,0.0,1.0,,,False,SOFT,1.0,True,Williams,25,3.0,False,10,British Grand Prix,True,C3,False,,,,,,
-0 days 01:04:38.967000,ZHO,24,,0.0,1.0,,,False,MEDIUM,1.0,True,Alfa Romeo,25,2.0,False,10,British Grand Prix,True,C2,False,,,,,,
 0 days 01:04:57.706000,RIC,3,166.878,1.0,1.0,0 days 00:22:26.215000,0 days 01:04:52.979000,False,MEDIUM,1.0,True,McLaren,25,10.0,False,10,British Grand Prix,True,C2,False,72.694,77.183,76.368,84.375,4.481,2.759
 0 days 01:58:15.588000,RIC,3,,2.0,2.0,0 days 01:55:56.273000,,False,MEDIUM,2.0,False,McLaren,1,11.0,False,10,British Grand Prix,True,C2,False,,,,,,
 0 days 02:00:24.434000,RIC,3,128.846,3.0,2.0,,,True,MEDIUM,3.0,False,McLaren,1,6.0,True,10,British Grand Prix,True,C2,True,34.662,36.802,38.336,42.356,-2.201,-1.68
@@ -10536,7 +10533,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 03:17:27.755000,LAT,6,93.937,50.0,4.0,,,False,SOFT,12.0,False,Williams,1,13.0,True,10,British Grand Prix,True,C3,True,-0.247,-0.262,3.427,3.786,1.029,1.108
 0 days 03:19:02.622000,LAT,6,94.867,51.0,4.0,,,False,SOFT,13.0,False,Williams,1,13.0,True,10,British Grand Prix,True,C3,True,0.683,0.725,4.357,4.814,2.205,2.38
 0 days 03:20:37.285000,LAT,6,94.663,52.0,4.0,,,False,SOFT,14.0,False,Williams,1,13.0,True,10,British Grand Prix,True,C3,True,0.479,0.509,4.153,4.588,2.238,2.421
-0 days 01:04:38.967000,RUS,63,,0.0,1.0,,,False,HARD,1.0,True,Mercedes,25,1.0,False,10,British Grand Prix,True,C1,False,,,,,,
 0 days 01:04:56.037000,BOT,77,162.397,1.0,1.0,0 days 00:23:41.762000,0 days 01:04:51.154000,False,MEDIUM,1.0,True,Alfa Romeo,25,9.0,False,10,British Grand Prix,True,C2,False,68.213,72.425,71.887,79.424,0.0,0.0
 0 days 01:58:16.284000,BOT,77,,2.0,2.0,0 days 01:55:46.990000,,False,MEDIUM,1.0,True,Alfa Romeo,1,12.0,False,10,British Grand Prix,True,C2,False,,,,,,
 0 days 02:00:27.718000,BOT,77,131.434,3.0,2.0,,,True,MEDIUM,2.0,True,Alfa Romeo,1,16.0,True,10,British Grand Prix,True,C2,True,37.25,39.55,40.924,45.215,0.387,0.295
@@ -14793,7 +14789,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:26:32.640000,NOR,4,114.749,42.0,3.0,,,False,MEDIUM,13.0,True,McLaren,1,12.0,True,14,Belgian Grand Prix,True,C3,True,0.428,0.374,5.395,4.934,0.369,0.323
 0 days 02:28:27.655000,NOR,4,115.015,43.0,3.0,,,False,MEDIUM,14.0,True,McLaren,1,12.0,True,14,Belgian Grand Prix,True,C3,True,0.694,0.607,5.661,5.177,0.907,0.795
 0 days 02:30:22.412000,NOR,4,114.757,44.0,3.0,,,False,MEDIUM,15.0,True,McLaren,2,12.0,True,14,Belgian Grand Prix,True,C3,False,0.436,0.381,5.403,4.941,0.997,0.876
-0 days 01:04:38.725000,HAM,44,,0.0,1.0,,,False,MEDIUM,1.0,True,Mercedes,2,1.0,False,14,Belgian Grand Prix,True,C3,False,,,,,,
 0 days 01:04:51.113000,MSC,47,126.331,1.0,1.0,0 days 00:24:52.310000,,False,MEDIUM,1.0,True,Haas F1 Team,2,17.0,False,14,Belgian Grand Prix,True,C3,False,12.01,10.506,16.977,15.525,2.291,1.847
 0 days 01:07:18.282000,MSC,47,147.169,2.0,1.0,,,True,MEDIUM,2.0,True,Haas F1 Team,24,15.0,False,14,Belgian Grand Prix,True,C3,False,32.848,28.733,37.815,34.58,7.171,5.122
 0 days 01:10:20.884000,MSC,47,,3.0,1.0,,,False,MEDIUM,3.0,True,Haas F1 Team,4,15.0,False,14,Belgian Grand Prix,True,C3,False,,,,,,
@@ -18547,7 +18542,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 04:02:00.757000,TSU,22,107.094,26.0,4.0,,,False,INTERMEDIATE,6.0,True,AlphaTauri,1,13.0,True,18,Japanese Grand Prix,False,INTERMEDIATE,False,,,2.683,2.57,-2.398,-2.19
 0 days 04:03:47.938000,TSU,22,107.181,27.0,4.0,,,False,INTERMEDIATE,7.0,True,AlphaTauri,1,13.0,True,18,Japanese Grand Prix,False,INTERMEDIATE,False,,,2.77,2.653,-2.551,-2.325
 0 days 04:05:35.577000,TSU,22,107.639,28.0,4.0,,,False,INTERMEDIATE,8.0,True,AlphaTauri,1,13.0,True,18,Japanese Grand Prix,False,INTERMEDIATE,False,,,3.228,3.092,-2.202,-2.005
-0 days 01:04:37.974000,ALB,23,,0.0,1.0,,,False,INTERMEDIATE,1.0,True,Williams,24,2.0,False,18,Japanese Grand Prix,False,INTERMEDIATE,False,,,,,,
 0 days 01:05:23.274000,ZHO,24,167.346,1.0,1.0,0 days 00:24:28.458000,,False,INTERMEDIATE,1.0,True,Alfa Romeo,24,17.0,False,18,Japanese Grand Prix,False,INTERMEDIATE,False,,,62.935,60.276,19.476,13.171
 0 days 01:08:23.605000,ZHO,24,,2.0,1.0,,0 days 01:08:20.257000,False,INTERMEDIATE,2.0,True,Alfa Romeo,45,17.0,False,18,Japanese Grand Prix,False,INTERMEDIATE,False,,,,,,
 0 days 03:17:26.677000,ZHO,24,,3.0,2.0,0 days 03:15:10.307000,,False,WET,1.0,True,Alfa Romeo,1,17.0,False,18,Japanese Grand Prix,False,WET,False,,,,,,
@@ -18744,7 +18738,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 04:01:26.099000,VET,5,109.358,26.0,3.0,,,False,INTERMEDIATE,21.0,True,Aston Martin,1,6.0,True,18,Japanese Grand Prix,False,INTERMEDIATE,False,,,4.947,4.738,-0.134,-0.122
 0 days 04:03:15.921000,VET,5,109.822,27.0,3.0,,,False,INTERMEDIATE,22.0,True,Aston Martin,1,6.0,True,18,Japanese Grand Prix,False,INTERMEDIATE,False,,,5.411,5.182,0.09,0.082
 0 days 04:05:06.289000,VET,5,110.368,28.0,3.0,,,False,INTERMEDIATE,23.0,True,Aston Martin,1,6.0,True,18,Japanese Grand Prix,False,INTERMEDIATE,False,,,5.957,5.705,0.527,0.48
-0 days 01:04:37.974000,SAI,55,,0.0,1.0,,,False,INTERMEDIATE,1.0,True,Ferrari,24,1.0,False,18,Japanese Grand Prix,False,INTERMEDIATE,False,,,,,,
 0 days 01:05:14.872000,LAT,6,158.944,1.0,1.0,0 days 00:22:41.853000,,False,INTERMEDIATE,1.0,True,Williams,24,15.0,False,18,Japanese Grand Prix,False,INTERMEDIATE,False,,,54.533,52.229,11.074,7.489
 0 days 01:08:18.623000,LAT,6,,2.0,1.0,,0 days 01:08:15.262000,False,INTERMEDIATE,2.0,True,Williams,45,15.0,False,18,Japanese Grand Prix,False,INTERMEDIATE,False,,,,,,
 0 days 03:17:20.240000,LAT,6,,3.0,2.0,0 days 03:15:02.611000,,False,WET,1.0,True,Williams,1,15.0,False,18,Japanese Grand Prix,False,WET,False,,,,,,
@@ -21626,7 +21619,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:38:12.694000,STR,18,75.607,69.0,3.0,,,False,SOFT,21.0,False,Aston Martin,1,10.0,True,21,São Paulo Grand Prix,True,C4,True,-1.086,-1.416,1.822,2.469,0.0,0.0
 0 days 02:39:28.407000,STR,18,75.713,70.0,3.0,,,False,SOFT,22.0,False,Aston Martin,1,10.0,True,21,São Paulo Grand Prix,True,C4,True,-0.98,-1.278,1.928,2.613,0.0,0.0
 0 days 02:40:44.126000,STR,18,75.719,71.0,3.0,,,False,SOFT,23.0,False,Aston Martin,1,10.0,True,21,São Paulo Grand Prix,True,C4,True,-0.974,-1.27,1.934,2.621,-0.04,-0.053
-0 days 01:03:15.105000,MAG,20,,0.0,1.0,,,False,MEDIUM,1.0,True,Haas F1 Team,24,1.0,False,21,São Paulo Grand Prix,True,C3,False,,,,,,
 0 days 01:03:41.451000,TSU,22,,1.0,1.0,0 days 01:02:06.807000,,False,MEDIUM,1.0,True,AlphaTauri,24,18.0,False,21,São Paulo Grand Prix,True,C3,False,,,,,,
 0 days 01:05:32.775000,TSU,22,111.324,2.0,1.0,,,True,MEDIUM,2.0,True,AlphaTauri,4,18.0,False,21,São Paulo Grand Prix,True,C3,False,34.631,45.155,37.539,50.876,-1.14,-1.014
 0 days 01:07:30.391000,TSU,22,117.616,3.0,1.0,,,False,MEDIUM,3.0,True,AlphaTauri,4,18.0,False,21,São Paulo Grand Prix,True,C3,False,40.923,53.359,43.831,59.404,-1.66,-1.392
@@ -21839,7 +21831,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:38:17.180000,ZHO,24,76.086,69.0,3.0,,,False,SOFT,32.0,True,Alfa Romeo,1,13.0,True,21,São Paulo Grand Prix,True,C4,True,-0.607,-0.791,2.301,3.119,0.479,0.634
 0 days 02:39:33.478000,ZHO,24,76.298,70.0,3.0,,,False,SOFT,33.0,True,Alfa Romeo,1,13.0,True,21,São Paulo Grand Prix,True,C4,True,-0.395,-0.515,2.513,3.406,0.585,0.773
 0 days 02:40:49.899000,ZHO,24,76.421,71.0,3.0,,,False,SOFT,34.0,True,Alfa Romeo,1,13.0,True,21,São Paulo Grand Prix,True,C4,True,-0.272,-0.355,2.636,3.573,0.662,0.874
-0 days 01:03:15.105000,RIC,3,,0.0,1.0,,,False,SOFT,1.0,True,McLaren,24,2.0,False,21,São Paulo Grand Prix,True,C4,False,,,,,,
 0 days 01:03:34.900000,OCO,31,,1.0,1.0,0 days 00:24:52.338000,,False,SOFT,1.0,True,Alpine,24,14.0,False,21,São Paulo Grand Prix,True,C4,False,,,,,,
 0 days 01:05:26.620000,OCO,31,111.72,2.0,1.0,,,True,SOFT,2.0,True,Alpine,4,14.0,False,21,São Paulo Grand Prix,True,C4,False,35.027,45.672,37.935,51.413,-0.744,-0.662
 0 days 01:07:25.467000,OCO,31,118.847,3.0,1.0,,,False,SOFT,3.0,True,Alpine,4,14.0,False,21,São Paulo Grand Prix,True,C4,False,42.154,54.965,45.062,61.072,-0.429,-0.36

--- a/Data/grand_prix/transformed_grand_prix_laps_2023.csv
+++ b/Data/grand_prix/transformed_grand_prix_laps_2023.csv
@@ -2229,7 +2229,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:59:00.044000,ALO,14,,56.0,3.0,0 days 02:55:15.488000,,False,SOFT,5.0,False,Aston Martin,1,3.0,False,3,Australian Grand Prix,True,C4,False,,,,,,
 0 days 03:32:07.678000,ALO,14,,57.0,3.0,,0 days 03:01:26.171000,False,SOFT,6.0,False,Aston Martin,25,3.0,False,3,Australian Grand Prix,True,C4,False,,,,,,
 0 days 03:34:56.410000,ALO,14,,58.0,4.0,0 days 03:32:11.291000,,False,SOFT,5.0,False,Aston Martin,1,3.0,False,3,Australian Grand Prix,True,C4,False,,,,,,
-0 days 01:03:55,LEC,16,,0.0,1.0,,,False,MEDIUM,1.0,True,Ferrari,24,1.0,False,3,Australian Grand Prix,True,C3,False,,,,,,
 0 days 01:04:05.198000,STR,18,108.052,1.0,1.0,0 days 00:24:12.765000,,False,MEDIUM,2.0,False,Aston Martin,24,7.0,False,3,Australian Grand Prix,True,C3,False,25.461,30.828,27.817,34.669,-5.724,-5.031
 0 days 01:06:16.340000,STR,18,131.142,2.0,1.0,,,True,MEDIUM,3.0,False,Aston Martin,4,7.0,False,3,Australian Grand Prix,True,C3,False,48.551,58.785,50.907,63.447,0.344,0.263
 0 days 01:08:24.097000,STR,18,127.757,3.0,1.0,,,True,MEDIUM,4.0,False,Aston Martin,4,7.0,False,3,Australian Grand Prix,True,C3,False,45.166,54.686,47.522,59.229,2.96,2.372
@@ -13637,7 +13636,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 01:43:37.378000,SAI,55,120.162,21.0,2.0,,,False,MEDIUM,14.0,True,Ferrari,1,19.0,True,12,Belgian Grand Prix,True,C3,True,7.426,6.587,12.857,11.982,3.958,3.406
 0 days 01:45:35.327000,SAI,55,117.949,22.0,2.0,,,False,MEDIUM,15.0,True,Ferrari,1,19.0,True,12,Belgian Grand Prix,True,C3,True,5.213,4.624,10.644,9.919,1.229,1.053
 0 days 01:47:38.690000,SAI,55,123.363,23.0,2.0,,0 days 01:47:34.913000,False,MEDIUM,16.0,True,Ferrari,1,19.0,False,12,Belgian Grand Prix,True,C3,False,10.627,9.426,16.058,14.965,8.599,7.493
-0 days 01:04:38.140000,PIA,81,,0.0,1.0,,,False,MEDIUM,1.0,True,McLaren,1,1.0,False,12,Belgian Grand Prix,True,C3,False,,,,,,
 0 days 01:03:36.822000,VER,1,91.585,1.0,1.0,0 days 00:14:44.885000,,False,SOFT,1.0,True,Red Bull Racing,1,1.0,False,13,Dutch Grand Prix,True,C3,False,15.201,19.901,17.748,24.037,-6.863,-6.971
 0 days 01:05:26.794000,VER,1,109.972,2.0,1.0,,0 days 01:05:25.519000,False,SOFT,2.0,True,Red Bull Racing,1,3.0,False,13,Dutch Grand Prix,True,C3,False,33.588,43.973,36.135,48.939,-1.933,-1.727
 0 days 01:07:15.452000,VER,1,108.658,3.0,2.0,0 days 01:05:45.581000,,False,INTERMEDIATE,1.0,True,Red Bull Racing,1,6.0,False,13,Dutch Grand Prix,False,INTERMEDIATE,False,32.274,42.252,34.821,47.159,-0.35,-0.321
@@ -15393,7 +15391,6 @@ Time,Driver,DriverNumber,LapTime,LapNumber,Stint,PitOutTime,PitInTime,IsPersonal
 0 days 02:34:48.759000,MAG,20,87.054,49.0,3.0,,,False,MEDIUM,16.0,True,Haas F1 Team,1,18.0,True,14,Italian Grand Prix,True,C4,True,0.092,0.106,1.982,2.33,-0.13,-0.149
 0 days 02:36:15.663000,MAG,20,86.904,50.0,3.0,,,False,MEDIUM,17.0,True,Haas F1 Team,1,18.0,True,14,Italian Grand Prix,True,C4,True,-0.058,-0.067,1.832,2.153,-0.023,-0.026
 0 days 02:38:45.663000,MAG,20,,51.0,3.0,,,True,MEDIUM,18.0,True,Haas F1 Team,0,,False,14,Italian Grand Prix,True,C4,False,,,,,,
-0 days 01:23:49.013000,TSU,22,,0.0,1.0,,,False,MEDIUM,4.0,False,AlphaTauri,1,1.0,False,14,Italian Grand Prix,True,C4,False,,,,,,
 0 days 01:23:52.681000,ALB,23,90.785,1.0,1.0,0 days 00:15:30.021000,,False,MEDIUM,4.0,False,Williams,1,7.0,False,14,Italian Grand Prix,True,C4,False,3.823,4.396,5.713,6.715,-1.935,-2.087
 0 days 01:25:19.748000,ALB,23,87.067,2.0,1.0,,,True,MEDIUM,5.0,False,Williams,1,6.0,True,14,Italian Grand Prix,True,C4,True,0.105,0.121,1.995,2.345,-0.945,-1.074
 0 days 01:26:46.326000,ALB,23,86.578,3.0,1.0,,,True,MEDIUM,6.0,False,Williams,1,6.0,True,14,Italian Grand Prix,True,C4,True,-0.384,-0.442,1.506,1.77,-0.782,-0.895

--- a/f1_visualization/preprocess.py
+++ b/f1_visualization/preprocess.py
@@ -266,6 +266,7 @@ def load_laps() -> defaultdict[int, defaultdict[str, pd.DataFrame]]:
             df = correct_dtype(df)
             df = fill_compound(df)
 
+        df = df[df["LapNumber"] != 0]
         df_dict[season][session][data_type] = df
 
     return df_dict


### PR DESCRIPTION
While working on #114, we discovered that sometimes the F1 API will include a lap zero in its response. These laps are always never property populated and not intended to be included in the dataset.

These rows are dropped and the preprocessing procedure modified to reject them.