### PR TITLE
Add dummy element to ensure proper callback order

### DIFF
--- a/app.py
+++ b/app.py
@@ -464,13 +464,27 @@ def set_starting_grid_switch(
 
 
 @callback(
+    Output("laps-data-sequencer", "children"), Input("laps", "data"), prevent_initial_call=True
+)
+def after_laps_data_callback(included_laps: dict) -> str:
+    """
+    Populate an invisible element that serves as input for other callbacks.
+
+    This serves to ensure those other callbacks are only fired after laps data is loaded.
+    """
+    # not that it matters, but this contains the column names of the laps dataframe
+    return str(included_laps.keys())
+
+
+@callback(
     Output("strategy-plot", "figure"),
     Input("drivers", "value"),
+    Input("laps-data-sequencer", "children"),  # ensure laps data has finished loading
     State("laps", "data"),
     State("session-info", "data"),
 )
 def render_strategy_plot(
-    drivers: list[str], included_laps: dict, session_info: Session_info
+    drivers: list[str], _: str, included_laps: dict, session_info: Session_info
 ) -> go.Figure:
     """Filter laps and configure strategy plot title."""
     # return empty figure on startup
@@ -583,6 +597,7 @@ def render_lineplot(
     Input("drivers", "value"),
     Input("upper-bound-dist", "value"),
     Input("boxplot", "value"),
+    Input("laps-data-sequencer", "children"),  # ensure laps data has finished loading
     State("laps", "data"),
     State("session-info", "data"),
     State("teammate-comp", "value"),
@@ -591,6 +606,7 @@ def render_distplot(
     drivers: list[str],
     upper_bound: int,
     boxplot: bool,
+    _: str,
     included_laps: dict,
     session_info: Session_info,
     teammate_comp: bool,

--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -489,5 +489,7 @@ app_layout = dbc.Container(
         ),
         html.Br(),
         dbc.Row(external_links),
+        # this component exists solely to enforce callback order
+        html.Span(id="laps-data-sequencer", hidden=True),
     ]
 )

--- a/dashboard/layout.py
+++ b/dashboard/layout.py
@@ -107,20 +107,8 @@ add_gap_row = dbc.Row(
     )
 )
 
-strategy_hint = dbc.Alert(
-    [
-        html.H4("Hint", className="alert-heading"),
-        html.P("Try reloading the session if no plot is shown."),
-    ],
-    color="info",
-    dismissable=True,
-)
-
 strategy_tab = dbc.Tab(
-    dbc.Card(
-        dbc.CardBody([strategy_hint, html.Br(), dcc.Loading(dcc.Graph(id="strategy-plot"))])
-    ),
-    label="Strategy",
+    dbc.Card(dbc.CardBody(dcc.Loading(dcc.Graph(id="strategy-plot")))), label="Strategy"
 )
 
 scatter_y_options = [


### PR DESCRIPTION
Ref: #98 

The problem of the strategy plot (and the distribution plot although this was previously unnoticed) often not rendering on the initial session load is due to a race condition of sort between the different callbacks. This can also be the cause for why sometimes the strategy plot remains unchanged when a new session is loaded.

When the `load-session.n_clicks` property is updated, two callbacks are simultaneously triggered to update both the `session-info` data store, which populates the `drivers.value` property, and the `laps` data store. Since the latter is much bigger in terms of memory, it tends to take longer to run.

See the previous callback decorator for the strategy plot:

```
@callback(
    Output("strategy-plot", "figure"),
    Input("drivers", "value"),
    State("laps", "data"),
    State("session-info", "data"),
)
```

This callback is fired as soon as `drivers.value` is populated, at which point `laps.data` is read. However, it might not be populated yet, leading to the plot not rendering.

This PR introduces a dummy element with a callback that sits between `laps.data` and the strategy plot. With this indirect depency in place, all the plots should only load after the laps data is properly loaded